### PR TITLE
Add textual description of a schema

### DIFF
--- a/modules/base/Base.ttl
+++ b/modules/base/Base.ttl
@@ -3,6 +3,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix ids: <https://schema.industrialdataspace.org/> .
 @prefix ids_base: <https://schema.industrialdataspace.org/base/> .

--- a/modules/dataEndpoint/DataEndpoint.ttl
+++ b/modules/dataEndpoint/DataEndpoint.ttl
@@ -285,11 +285,17 @@ ids_dep:conformsToStandard a owl:DatatypeProperty;
     rdfs:label "conformsToStandard"@en;
     rdfs:comment "The standard the Representation conforms to."@en.
 
-ids_dep:conformsToStructure a owl:DatatypeProperty;
+ids_dep:schemaLink a owl:DatatypeProperty;
     rdfs:domain ids_dep:Representation;
     rdfs:range xsd:anyURI;
-    rdfs:label "conformsToStructure"@en;
+    rdfs:label "schemaLink"@en;
     rdfs:comment "Links to a document that contains additional information like class and type descriptions or integrity constraints describing the Representation's structure."@en.
+
+ids_dep:schemaDefinition a owl:DatatypeProperty;
+    rdfs:domain ids_dep:Representation;
+    rdfs:range xsd:string;
+    rdfs:label "schemaDefinition"@en;
+    rdfs:comment "Formal definition of the Representation's structure, matching its data and media type (e.g, JSON Schema or XSD)."@en.
 
 ids_dep:transformationRule a owl:DatatypeProperty;
     rdfs:domain ids_dep:Representation;


### PR DESCRIPTION
In addition to linking to a schema description on the Web, we probably also want a textual property describing the schema (e.g., in case of custom JSON or XML structures that need to be parsed by a client)