### PR TITLE
Message support for security tokens

### DIFF
--- a/codes/TokenFormat.ttl
+++ b/codes/TokenFormat.ttl
@@ -3,27 +3,27 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix ids: <https://w3id.org/idsa/core/> .
-@prefix idsc_atf: <https://w3id.org/idsa/code/authtokenformat/> .
+@prefix idsc_atf: <https://w3id.org/idsa/code/tokenformat/> .
 @prefix idsm: <https://w3id.org/idsa/metamodel/> .
 
 # Instances
 # ---------
 
-idsc_atf:JWT a ids:AuthenticationTokenFormat ;
+idsc_atf:JWT a ids:TokenFormat ;
     rdfs:label "Json Web Token".
 
-idsc_atf:SWT a ids:AuthenticationTokenFormat ;
+idsc_atf:SWT a ids:TokenFormat ;
     rdfs:label "Simple Web Token".
 
-idsc_atf:SAML_1_1 a ids:AuthenticationTokenFormat ;
+idsc_atf:SAML_1_1 a ids:TokenFormat ;
     rdfs:label "Security Assertion Markup Language (SAML) 1.1".
 
-idsc_atf:SAML_2_0 a ids:AuthenticationTokenFormat ;
+idsc_atf:SAML_2_0 a ids:TokenFormat ;
     rdfs:label "Security Assertion Markup Language (SAML) 2.0".
 
-idsc_atf:OTHER a ids:AuthenticationTokenFormat ;
+idsc_atf:OTHER a ids:TokenFormat ;
     rdfs:label "Other".
 
-idsc_atf:UNKNOWN a ids:AuthenticationTokenFormat ;
+idsc_atf:UNKNOWN a ids:TokenFormat ;
     rdfs:label "Unknown".
 

--- a/examples/INTER1.ttl
+++ b/examples/INTER1.ttl
@@ -11,7 +11,7 @@
     ids:recipientConnector broker1: ;
     ids:issued "2018-10-01T15:57:00"^^xsd:dateTime ;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ] .

--- a/examples/INTER2.ttl
+++ b/examples/INTER2.ttl
@@ -24,8 +24,8 @@
     ids:recipientConnector broker1: ;
     ids:issued "2018-10-01T15:57:00"^^xsd:dateTime;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ].
 

--- a/examples/INTER3.ttl
+++ b/examples/INTER3.ttl
@@ -19,8 +19,8 @@ conn3:inter3_r a ids:ContractRequestMessage;
     ids:recipientConnector conn2: ;
     ids:issued "2018-10-01T15:57:00"^^xsd:dateTime;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ];
     ids:baseContractOffer data1:offer.
@@ -31,8 +31,8 @@ conn2:inter3_o a ids:ContractOfferMessage;
     ids:recipientConnector conn3: ;
     ids:issued "2018-10-01T15:58:00"^^xsd:dateTime;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ];
     ids:correlationMessage conn3:inter3_r.
@@ -43,8 +43,8 @@ conn3:inter3_a a ids:ContractAgreementMessage;
     ids:recipientConnector conn2: ;
     ids:issued "2018-10-01T15:58:00"^^xsd:dateTime;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ];
     ids:correlationMessage conn2:inter3_o.
@@ -55,8 +55,8 @@ conn2:inter3_a a ids:ContractAgreementMessage;
     ids:recipientConnector conn3: ;
     ids:issued "2018-10-01T15:59:00"^^xsd:dateTime;
     ids:modelVersion "1.0.0";
-    ids:authenticationToken [
-        a ids:AuthenticationToken;
+    ids:authorizationToken [
+        a ids:Token;
         ids:tokenValue "2YotnFZFEjr1zCsicMWpAA"
     ];
     ids:correlationMessage conn3:inter3_a.

--- a/model/communication/Message.ttl
+++ b/model/communication/Message.ttl
@@ -95,12 +95,19 @@ ids:recipientAgent
     rdfs:range ids:Agent;
     rdfs:comment "The Agent for which the Mesaage is intended."@en.
 
-ids:authenticationToken
+ids:securityToken
     a owl:ObjectProperty;
-    rdfs:label "authentication token"@en;
+    rdfs:label "Security token"@en;
     rdfs:domain ids:Message;
-    rdfs:range ids:AuthenticationToken;
-    rdfs:comment "An authentication token like JSON Web Token."@en.
+    rdfs:range ids:Token;
+    rdfs:comment "A token representing a claim that the message sender supports a certain security profile."@en.
+
+ids:authorizationToken
+    a owl:ObjectProperty;
+    rdfs:label "Authorization token"@en;
+    rdfs:domain ids:Message;
+    rdfs:range ids:Token;
+    rdfs:comment "An authorization token like JSON Web Token."@en.
 
 ids:transferContract
     a owl:ObjectProperty;
@@ -109,4 +116,3 @@ ids:transferContract
     rdfs:domain ids:Message;
     rdfs:range ids:Contract;
     rdfs:comment "The contract which is (or will be) the legal basis of the data transfer."@en.
-

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -20,10 +20,6 @@ ids:Connector
         idsm:constraint idsm:NotNull;
     ];
     idsm:validation [
-        idsm:forProperty ids:securityProfile;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
         idsm:forProperty ids:host;
         idsm:relationType idsm:OneToMany;
     ].

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -9,33 +9,32 @@
 # Classes
 # -------
 
-ids:AuthenticationToken
+ids:Token
     a owl:Class;
-    rdfs:label "Authentication Token."@en;
-    rdfs:comment "Authentication token mediated as part of the message."@en ;
+    rdfs:label "Token."@en;
+    rdfs:comment "A token (e.g., for authorization) mediated as part of the message."@en ;
     idsm:validation [
         idsm:forProperty ids:tokenValue;
         idsm:constraint idsm:NotNull;
     ].
 
-ids:AuthenticationTokenFormat a owl:Class;
+ids:TokenFormat a owl:Class;
     idsm:abstract true;
-    rdfs:label "Authentication token format"@en;
-    rdfs:comment "Authentication Token Format."@en.
-
+    rdfs:label "Token format"@en;
+    rdfs:comment "Possible formats for (security-related) tokens."@en.
 
 # Properties
 # ----------
 
 ids:tokenValue a owl:DatatypeProperty;
     rdfs:label "tokenValue"@en;
-    rdfs:domain ids:AuthenticationToken;
+    rdfs:domain ids:Token;
     rdfs:range xsd:string ; # xsd:base64Binary;
     rdfs:comment "An authentication token value like JSON Web Token."@en.
 
 ids:tokenFormat a owl:ObjectProperty;
     rdfs:label "tokenFormat"@en;
-    rdfs:domain ids:AuthenticationToken;
-    rdfs:range ids:AuthenticationTokenFormat;
+    rdfs:domain ids:Token;
+    rdfs:range ids:TokenFormat;
     rdfs:comment "Describes the format of the authentication token."@en.
 


### PR DESCRIPTION
Generalize AuthenticationToken class to Token and support 2 tokens to be attached to a message: securityToken (i.e. a JWT that claims support of a certain security profile) and authorization Token (for usage in custom autorization scenarios between connector)