### PR TITLE
Add new connector property indicating the default host

### DIFF
--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -24,6 +24,10 @@ ids:Connector
         idsm:constraint idsm:NotNull;
     ];
     idsm:validation [
+        idsm:forProperty ids:defaultHost;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
         idsm:forProperty ids:host;
         idsm:relationType idsm:OneToMany;
     ].
@@ -41,7 +45,6 @@ ids:TrustedConnector rdfs:subClassOf ids:Connector ;
 # Properties
 # ----------
 
-# renamed from ids:connectionOption
 ids:host
     a owl:ObjectProperty;
     rdfs:label "host"@en;
@@ -49,6 +52,13 @@ ids:host
     rdfs:domain ids:Connector;
     rdfs:range ids:Host;
     rdfs:comment "Networked host operated by the Connector in order to serve and consume resource content and services."@en.
+
+ids:defaultHost
+    a owl:ObjectProperty;
+    rdfs:label "Default Host"@en;
+    rdfs:domain ids:Connector;
+    rdfs:range ids:Host;
+    rdfs:comment "Indicates the default host that should be used for basic infrastructure interactions, e.g., providing the self description."@en.
 
 ids:securityProfile a owl:ObjectProperty;
     rdfs:domain ids:Connector;

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -24,10 +24,6 @@ ids:Connector
         idsm:constraint idsm:NotNull;
     ];
     idsm:validation [
-        idsm:forProperty ids:defaultHost;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
         idsm:forProperty ids:host;
         idsm:relationType idsm:OneToMany;
     ].


### PR DESCRIPTION
So far the agreement was that the URL where the connector is reachable is the same one that is used as the subject for the connector self description. That might be too restrictive in practical operation. Therefore we should assume that the the resource describing a connector (i.e., the RDF connector instance) is a URI, i.e. it doesn't need to be resolvable (though that would be nice). That URI can act as a unique identifier (UUID) of the connector on the IDS ecosystem.
As a consequence, connectors need to define a default host that is resolvable and provides the standard interfaces to send and receive messages according to the information model. This is the scope of this pull request.