### PR TITLE
Opaque content type added

### DIFF
--- a/examples/DATA1.ttl
+++ b/examples/DATA1.ttl
@@ -10,12 +10,6 @@
 @prefix part1: <https://im.internationaldataspaces.org/participant/part1> .
 
 data1:
-    # Basic example, download of simple content     
-    # - Resource is equivalent with published content here, since only a single one
-    # - Two equivalent representations are provided, PDF and DOC
-    # - Download, i.e. non-interactive access - no interface definition needed
-    # - Significant IP derived from plain sources (data2), commercial use
-    #
     a ids:Text ;
     ids:title "European highway statistics - accident report"@en ;
     ids:description "Detailed accident analysis report based on European highway statistics data 2000 - 2017."@en;

--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -10,7 +10,7 @@
 # -------
 
 ids:DigitalContent
-    a owl:Class;
+    a owl:Class;    
     rdfs:subClassOf ids:Described, dcat:Dataset;
     rdfs:label "Digital content"@en ;
     rdfs:comment "Digital content of a particular type providing hints on its usage, e.g. listening to an Audio, navigating a Structure or accessing a List by an index." ;
@@ -46,6 +46,7 @@ ids:DigitalContent
         idsm:forProperty ids:representation;
         idsm:relationType idsm:OneToMany;
     ];
+    idsm:abstract true ;
     rdfs:seeAlso
         <https://en.wikipedia.org/wiki/Digital_content> ,
         <http://www.ontodm.com/doku.php?id=ontodt> ,

--- a/taxonomies/DigitalContent.ttl
+++ b/taxonomies/DigitalContent.ttl
@@ -15,7 +15,7 @@ ids:Data
     # ISO 19115: identifiable collection of data
     rdfs:subClassOf ids:DigitalContent, dctype:Dataset ;
     rdfs:label "Data"@en ;
-    rdfs:comment "Custom or generic (structured) data intended for machine processing, i.e. scalars or arrangements of data fields (optionally defined by a schema)."@en .
+    rdfs:comment "Custom or generic (semi)structured data intended for machine processing, i.e. atomic values or arrangements of data fields (optionally defined by a schema)."@en .
 
 
 ids:Text a owl:Class; # .. or "Document" ?
@@ -63,8 +63,11 @@ ids:Container a owl:Class;
    rdfs:seeAlso <https://tools.ietf.org/html/rfc2046#section-5.1> ;
    .
 
-# ids:BinaryContent a owl:Class; - obsolate, DigitalContent made a concrete class
-# rdfs:comment "Opaque, not further specified type of custom, binary content."@en .
+ids:OpaqueContent a owl:Class;
+   rdfs:subClassOf ids:DigitalContent ;
+   rdfs:label "Opaque content";
+   rdfs:comment "Opaque, not further specified type of custom, binary content."@en ;  
+   .
 
 # Derived content classes
 # -----------------------


### PR DESCRIPTION
The generic "DigitalContent" super-class was used when no decision about the type of content was made. In order to comply with common modelling patterns and a well-balanced taxonomy a dedicated subclass was created (OpaqueContent).