### PR TITLE
Certification Attributes

### DIFF
--- a/codes/KeyType.ttl
+++ b/codes/KeyType.ttl
@@ -1,0 +1,22 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix idsc_keytype: <https://w3id.org/idsa/code/keytype/> .
+@prefix idsm: <https://w3id.org/idsa/metamodel/> .
+
+# Instances
+# ---------
+
+idsc_keytype:DSA a ids:KeyType;
+    rdfs:label "DSA"@en.
+
+idsc_keytype:ECDSA a ids:KeyType;
+    rdfs:label "ECDSA"@en.
+
+idsc_keytype:RSA a ids:KeyType;
+    rdfs:label "RSA"@en.
+
+idsc_keytype:ED25519 a ids:KeyType;
+    rdfs:label "ED25519"@en.

--- a/model/governance/Certification.ttl
+++ b/model/governance/Certification.ttl
@@ -43,8 +43,6 @@ ids:CertificationLevel
 # ----------
 
 ids:includedCertificationLevel
-# for some reason this blows up processing by the sparql template engine
-#    a owl:TransitiveProperty;
     a owl:ObjectProperty;
     rdfs:subPropertyOf dct:isPartOf ;
     rdfs:seeAlso <https://www.w3.org/TR/odrl-vocab/#term-includedIn> ;

--- a/model/infrastructure/Component.ttl
+++ b/model/infrastructure/Component.ttl
@@ -77,3 +77,8 @@ ids:componentCertification
     rdfs:range ids:ComponentCertification;
     rdfs:comment "Certification issued for the given Infrastructure Component."@en.
 
+ids:publicKey a owl:ObjectProperty;
+    rdfs:label "Public Key"@en;
+    rdfs:domain ids:InfrastructureComponent;
+    rdfs:range ids:PublicKey;
+    rdfs:comment "Public Key that has been created for the Component."@en.

--- a/model/infrastructure/PublicKey.ttl
+++ b/model/infrastructure/PublicKey.ttl
@@ -1,0 +1,31 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix idsm: <https://w3id.org/idsa/metamodel/> .
+
+# Classes
+# -------
+
+ids:PublicKey a owl:Class ;
+    rdfs:label "Public Key"@en ;
+    rdfs:comment "Public key as used in asymmetric cryptography."@en.
+
+ids:KeyType a owl:Class;
+    rdfs:label "Key Type"@en ;
+    rdfs:comment "Cryptographic Key Type." ;
+    idsm:abstract true.
+
+# Properties of InfrastructureComponent
+# -------------------------------------
+
+ids:keyType a owl:ObjectProperty;
+    rdfs:domain ids:PublicKey;
+    rdfs:range ids:KeyType;
+    rdfs:label "Key Type"@en;
+    rdfs:comment "Type of the public key."@en.
+
+ids:keyValue a owl:DatatypeProperty;
+    rdfs:label "Key Value"@en ;
+    rdfs:comment "Binary representation of the key."@en ;
+    rdfs:domain ids:PublicKey ;
+    rdfs:range xsd:base64Binary.

--- a/taxonomies/Certification.ttl
+++ b/taxonomies/Certification.ttl
@@ -43,3 +43,11 @@ ids:ComponentCertification
     rdfs:label "Component Certification"@en ;
     rdfs:comment "Process and result of certifying a software component/servivce in order to become a certified part of the International Data Space infrastructure." .
 
+# Properties
+# ----------
+
+ids:membershipEnd a owl:DatatypeProperty ;
+    rdfs:label "membership end"@en;
+    rdfs:domain ids:ParticipantCertification ;
+    rdfs:range xsd:date ;
+    rdfs:comment "End of the participant's IDS membership."@en .


### PR DESCRIPTION
Based on the existing properties and classes and the changes in this pull request, the following certification properties can be expressed:

class Participant:
a participant's ids membership end (property membershipEnd)
a participant's certification expiry date (property lastValidDate)
a participant's certification status (= certification level) (property participantCertification)

class InfrastructureComponent:
a connector's certification expiry date (property lastValidDate)
a connector's certification status (= certification level) (property certificationLevel)

furthermore, public keys can now be attached to InfrastructureComponents
                      