### PR TITLE
Feature/participant messages

### DIFF
--- a/Ontology.ttl
+++ b/Ontology.ttl
@@ -29,7 +29,7 @@ ids:
     dct:publisher ids:IDSA ;
     dct:created "2017-09-26"^^xsd:date;
     dct:modified "2018-10-29"^^xsd:date;
-    owl:versionInfo "1.0.1-SNAPSHOT";
+    owl:versionInfo "1.0.2-SNAPSHOT";
     vann:preferredNamespaceUri "https://w3id.org/idsa/core/";
     vann:preferredNamespacePrefix "ids" ;
     void:vocabulary

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -79,8 +79,8 @@ ids:SelfDescriptionResponse a owl:Class ;
     rdfs:label "Self Description Response"@en ;
     rdfs:comment "Message containing the self-description of an Infrastructure Component."@en.
 
-# Broker Messages
-# ---------------
+# Connector-related Messages
+# --------------------------
 
 ids:ConnectorAvailableMessage a owl:Class;
     rdfs:subClassOf ids:NotificationMessage ;
@@ -101,6 +101,32 @@ ids:ConnectorConfigurationChangeMessage a owl:Class;
     rdfs:subClassOf ids:NotificationMessage ;
     rdfs:label "Connector Configuration Change Message"@en ;
     rdfs:comment "Event notifying the recipient(s) about a connector's configuration change. The payload of the message must contain the updated connector's self-description."@en.
+
+# Participant-related Messages
+# ----------------------------
+
+ids:ParticipantCertificateGrantedMessage a owl:Class;
+    rdfs:subClassOf ids:NotificationMessage ;
+    rdfs:label "Participant Certificate Granted Message"@en ;
+    rdfs:comment "Whenever a Participant has been successfully certified by the Certification Body, the Identity Provider can use this message to notify Infrastructure Components."@en.
+
+ids:ParticipantCertificateUnavailableMessage a owl:Class;
+    rdfs:subClassOf ids:NotificationMessage ;
+    rdfs:label "Participant Certificate Unavailable Message"@en ;
+    rdfs:comment "Indicates that a (previously certified) Participant is no more certified. This could happen, for instance, if the Certification Body revokes a granted certificate or if the certificate just expires."@en.
+
+ids:ParticipantCertificateSuspendedMessage a owl:Class;
+    rdfs:subClassOf ids:NotificationMessage ;
+    rdfs:label "Participant Certificate Suspended Message"@en ;
+    rdfs:comment "Event notifying the recipient(s) that a Participant is temporarily no more certified."@en.
+
+ids:ParticipantInformationChangedMessage a owl:Class;
+    rdfs:subClassOf ids:NotificationMessage ;
+    rdfs:label "Participant Information Changed Message"@en ;
+    rdfs:comment "Event notifying the recipient(s) that information describing this Participant has changed. This event is mainly intended for information describing the Participant that is NOT a direct subject of the certification process."@en.
+
+# Broker Messages
+# ---------------
 
 ids:BrokerQueryScope a owl:Class;
     rdfs:label "RejectionReason"@en ;


### PR DESCRIPTION
covers (partly) issue #60, extension of the messages taxonomy so that participant registries are notified on certification state changes performed by the certification body