### PR TITLE
Shacl ontology fix

### DIFF
--- a/docs/serializations/ontology.ttl
+++ b/docs/serializations/ontology.ttl
@@ -3128,7 +3128,7 @@ owl:Class rdf:type owl:Class .
 ###  https://w3id.org/idsa/core/CustomMediaType
 <https://w3id.org/idsa/core/CustomMediaType> rdf:type owl:Class ;
                                              rdfs:subClassOf <https://w3id.org/idsa/core/MediaType> ;
-                                             rdfs:comment "A selection of custom media types to be used for data published on the IDS when no IANA type is available." ;
+                                             rdfs:comment "A selection of custom media types to be used for data published on the IDS when no IANA type is available."@en ;
                                              rdfs:label "Custom Media Type"@en .
 
 
@@ -3544,7 +3544,7 @@ owl:Class rdf:type owl:Class .
 <https://w3id.org/idsa/core/OpaqueContent> rdf:type owl:Class ;
                                            rdfs:subClassOf <https://w3id.org/idsa/core/DigitalContent> ;
                                            rdfs:comment "Opaque, not further specified type of custom, binary content."@en ;
-                                           rdfs:label "Opaque content" .
+                                           rdfs:label "Opaque content"@en .
 
 
 ###  https://w3id.org/idsa/core/Operation
@@ -6799,7 +6799,7 @@ _:genid104 <https://w3id.org/idsa/metamodel/constraint> <https://w3id.org/idsa/m
                                          rdfs:label "Content type"@en .
 
 
-<https://w3id.org/idsa/core/Contract> rdfs:comment "Abstract set of rules governing the usage of a Resource." ;
+<https://w3id.org/idsa/core/Contract> rdfs:comment "Abstract set of rules governing the usage of a Resource."@en ;
                                       rdfs:label "Contract"@en .
 
 
@@ -6853,7 +6853,7 @@ _:genid104 <https://w3id.org/idsa/metamodel/constraint> <https://w3id.org/idsa/m
                                   rdfs:label "Host"@en .
 
 
-<https://w3id.org/idsa/core/IANAMediaType> rdfs:comment "The class of media types registered with IANA." ;
+<https://w3id.org/idsa/core/IANAMediaType> rdfs:comment "The class of media types registered with IANA."@en ;
                                            rdfs:label "IANA Media Type"@en ;
                                            rdfs:seeAlso <http://dx.doi.org/10.6084/m9.figshare.1608294> ,
                                                         <http://www.sparontologies.net/mediatype/> ,
@@ -6904,7 +6904,7 @@ _:genid104 <https://w3id.org/idsa/metamodel/constraint> <https://w3id.org/idsa/m
                                            rdfs:label "Managed entity"@en .
 
 
-<https://w3id.org/idsa/core/MediaType> rdfs:comment "General class of media types (formerly known as MIME types)." ;
+<https://w3id.org/idsa/core/MediaType> rdfs:comment "General class of media types (formerly known as MIME types)."@en ;
                                        rdfs:label "Media Type"@en .
 
 
@@ -6928,7 +6928,7 @@ _:genid104 <https://w3id.org/idsa/metamodel/constraint> <https://w3id.org/idsa/m
                                               rdfs:label "operation binding"@en .
 
 
-<https://w3id.org/idsa/core/OperationType> rdfs:comment "Enumerated types of operations expanding upon the Operation taxonomy." ;
+<https://w3id.org/idsa/core/OperationType> rdfs:comment "Enumerated types of operations expanding upon the Operation taxonomy."@en ;
                                            rdfs:label "Operation type"@en .
 
 
@@ -6964,7 +6964,7 @@ _:genid104 <https://w3id.org/idsa/metamodel/constraint> <https://w3id.org/idsa/m
                                     rdfs:label "Person"@en .
 
 
-<https://w3id.org/idsa/core/PolicyTemplate> rdfs:comment "The class of templates that describe a certain data usage policy." ;
+<https://w3id.org/idsa/core/PolicyTemplate> rdfs:comment "The class of "The class of templates that describe a certain data usage policy."@en that describe a certain data usage policy." ;
                                             rdfs:label "Policy template"@en .
 
 

--- a/model/communication/ApiDocumentType.ttl
+++ b/model/communication/ApiDocumentType.ttl
@@ -10,5 +10,5 @@
 ids:ApiDocumentType a owl:Class;
     idsm:abstract true ;
     rdfs:label "API Document Type"@en ;
-    rdfs:comment "The class of documents describing an API or service contract in a complete and concise way so that it can act as a basis for developing or (automatically) inferring clients.".
+    rdfs:comment "The class of documents describing an API or service contract in a complete and concise way so that it can act as a basis for developing or (automatically) inferring clients."@en.
 

--- a/model/communication/DataType.ttl
+++ b/model/communication/DataType.ttl
@@ -10,5 +10,5 @@
 
 ids:DataType a owl:Class;
     rdfs:label "Data Type"@en ;
-    rdfs:comment "The class of datatypes for usage by Operation Parameters.".
+    rdfs:comment "The class of datatypes for usage by Operation Parameters."@en.
 

--- a/model/communication/FaultPropagationRule.ttl
+++ b/model/communication/FaultPropagationRule.ttl
@@ -12,6 +12,6 @@
 ids:FaultPropagationRule
     a owl:Class;
     rdfs:label "Fault propagation rule"@en ;
-    rdfs:comment "Rules describing the relation and delivery of fault messages, i.e. whether they are omitted, replace or follow a regular operation message." ;
+    rdfs:comment "Rules describing the relation and delivery of fault messages, i.e. whether they are omitted, replace or follow a regular operation message."@en ;
     rdfs:seeAlso <https://www.w3.org/TR/wsdl20-adjuncts/#fault-rules> .
 

--- a/model/communication/OperationType.ttl
+++ b/model/communication/OperationType.ttl
@@ -11,7 +11,7 @@
 ids:OperationType
     a owl:Class;
     rdfs:label "Operation type"@en ;
-    rdfs:comment "Enumerated types of operations expanding upon the Operation taxonomy." ;
+    rdfs:comment "Enumerated types of operations expanding upon the Operation taxonomy."@en ;
     idsm:usage "Instances of Operation Type are used to more precisely specify the type, genre or interpretation of an Operation."@en ;
     .
 

--- a/model/communication/ParameterGroupingOperator.ttl
+++ b/model/communication/ParameterGroupingOperator.ttl
@@ -11,7 +11,7 @@
 ids:ParameterGroupingOperator a owl:Class;
     idsm:abstract true;
     rdfs:label "ParameterGroupingOperator"@en ;
-    rdfs:comment "The class of operators that relate all members of a ParameterGroup.".
+    rdfs:comment "The class of operators that relate all members of a ParameterGroup."@en.
 
 # Instances
 # ---------

--- a/model/communication/Protocol.ttl
+++ b/model/communication/Protocol.ttl
@@ -13,15 +13,15 @@
 ids:Protocol
     a owl:Class ;
     rdfs:label "Communication Protocol"@en ;
-    rdfs:comment "Set of communication rules by which a Service implements its Interface(s) in order to become invocable." .
+    rdfs:comment "Set of communication rules by which a Service implements its Interface(s) in order to become invocable."@en .
 
 #ids:ProtocolPhase
 #    a owl:Class ;
 #    rdfs:label "Protocol phase"@en ;
-#    rdfs:comment "Communication phase defined by the corresponding protocol standard." .
+#    rdfs:comment "Communication phase defined by the corresponding protocol standard."@en .
 
 #ids:ProtocolConstituent
 #    a owl:Class ;
 #    rdfs:label "Protocol constituent"@en ;
-#    rdfs:comment "Named constituent invloved within a Communication phase defined by the corresponding protocol standard." .
+#    rdfs:comment "Named constituent invloved within a Communication phase defined by the corresponding protocol standard."@en .
 

--- a/model/content/Concept.ttl
+++ b/model/content/Concept.ttl
@@ -15,7 +15,7 @@ ids:Concept
     rdfs:subClassOf skos:Concept;
     idsm:abstract true;
     rdfs:label "Concept"@en ;
-    rdfs:comment "Class of categories for classification of Resources.";
+    rdfs:comment "Class of categories for classification of Resources."@en;
     rdfs:seeAlso
         <https://www.w3.org/TR/vocab-dcat/#Property:dataset_theme> ,
         <https://github.com/w3c/dxwg/wiki/Data-aspects---semantics> .

--- a/model/content/ContentType.ttl
+++ b/model/content/ContentType.ttl
@@ -12,7 +12,7 @@ ids:ContentType
     a owl:Class;
     rdfs:subClassOf dct:DCMIType ;
     rdfs:label "Content type"@en ;
-    rdfs:comment "Enumerated types of content expanding upon the Digital Content hierarchy." ;
+    rdfs:comment "Enumerated types of content expanding upon the Digital Content hierarchy."@en ;
     idsm:usage "Instances of Content Type are used to more precisely specify the type, genre or interpretation of a Digital Content."@en ;
     .
 

--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -13,7 +13,7 @@ ids:DigitalContent
     a owl:Class;    
     rdfs:subClassOf ids:Described, dcat:Dataset;
     rdfs:label "Digital content"@en ;
-    rdfs:comment "Digital content of a particular type providing hints on its usage, e.g. listening to an Audio, navigating a Structure or accessing a List by an index." ;
+    rdfs:comment "Digital content of a particular type providing hints on its usage, e.g. listening to an Audio, navigating a Structure or accessing a List by an index."@en ;
     idsm:validation [
         idsm:forProperty ids:contentPart;
         idsm:relationType idsm:OneToMany;

--- a/model/content/MediaType.ttl
+++ b/model/content/MediaType.ttl
@@ -12,7 +12,7 @@ ids:MediaType
     a owl:Class;
     rdfs:subClassOf dct:MediaType ; # *not* restricted to IANA media types
     rdfs:label "Media Type"@en ;
-    rdfs:comment "General class of media types (formerly known as MIME types)." ;
+    rdfs:comment "General class of media types (formerly known as MIME types)."@en ;
     idsm:usage "ids:CustomMediaType is used only when no ids:IANAMediaType available."@en ;
     idsm:abstract true;
     .
@@ -21,13 +21,13 @@ ids:CustomMediaType
     a owl:Class ;
     rdfs:subClassOf ids:MediaType;
     rdfs:label "Custom Media Type"@en ;
-    rdfs:comment "A selection of custom media types to be used for data published on the IDS when no IANA type is available.".
+    rdfs:comment "A selection of custom media types to be used for data published on the IDS when no IANA type is available."@en.
 
 ids:IANAMediaType
     a owl:Class ;
     rdfs:subClassOf ids:MediaType;
     rdfs:label "IANA Media Type"@en ;
-    rdfs:comment "The class of media types registered with IANA.";
+    rdfs:comment "The class of media types registered with IANA."@en;
     rdfs:seeAlso <https://www.iana.org/assignments/media-types/> ; # authoritative IANA list
     rdfs:seeAlso <http://www.sparontologies.net/mediatype/> ; # RDF description of IANA-registered media types
     rdfs:seeAlso <http://dx.doi.org/10.6084/m9.figshare.1608294> ; # downloadable archive of SPAR Media Type ontology

--- a/model/contract/Contract.ttl
+++ b/model/contract/Contract.ttl
@@ -14,7 +14,7 @@ ids:Contract
     rdfs:subClassOf odrl:Policy;
     rdfs:label "Contract"@en ;
     idsm:abstract true;
-    rdfs:comment "Abstract set of rules governing the usage of a Resource.";
+    rdfs:comment "Abstract set of rules governing the usage of a Resource."@en;
     idsm:validation [
         idsm:forProperty ids:permission;
         idsm:relationType idsm:OneToMany;
@@ -33,7 +33,7 @@ ids:ContractAgreement
     a owl:Class;
     rdfs:subClassOf ids:Contract, odrl:Agreement;
     rdfs:label "Contract agreement"@en ;
-    rdfs:comment "Contract governing the actual usage of a Resource that has been agreed by all parties.";
+    rdfs:comment "Contract governing the actual usage of a Resource that has been agreed by all parties."@en;
     # End is optional
     idsm:validation [
         idsm:forProperty ids:contractStart;
@@ -45,7 +45,7 @@ ids:ContractRequest
     a owl:Class;
     rdfs:subClassOf ids:Contract, odrl:Request;
     rdfs:label "Contract request"@en ;
-    rdfs:comment "Contract issued by the Data Consumer requesting the usage of a Resource at particular conditions." ;
+    rdfs:comment "Contract issued by the Data Consumer requesting the usage of a Resource at particular conditions."@en;
     owl:disjointWith ids:ContractAgreement, ids:ContractOffer .
 
 ids:ContractOffer

--- a/model/contract/PolicyTemplate.ttl
+++ b/model/contract/PolicyTemplate.ttl
@@ -11,7 +11,7 @@
 ids:PolicyTemplate
     a owl:Class;
     rdfs:label "Policy template"@en ;
-    rdfs:comment "The class of templates that describe a certain data usage policy." ;
-    idsm:usage "Instances of this class conform to a certain textual representation which they need to indicate via a property."@en ;
+    rdfs:comment "The class of templates that describe a certain data usage policy."@en;
+    idsm:usage "Instances of this class conform to a certain textual representation which they need to indicate via a property."@en;
     .
 

--- a/model/governance/Certification.ttl
+++ b/model/governance/Certification.ttl
@@ -37,7 +37,7 @@ ids:CertificationLevel
     a owl:Class ;
     idsm:abstract true;
     rdfs:label "Certification Level"@en ;
-    rdfs:comment "Level of Certification".
+    rdfs:comment "Level of Certification"@en.
 
 # Properties
 # ----------

--- a/model/governance/Certification.ttl
+++ b/model/governance/Certification.ttl
@@ -24,14 +24,14 @@ ids:Certification
     a owl:Class ;
     rdfs:subClassOf ids:ManagedEntity ;
     rdfs:label "Certification"@en ;
-    rdfs:comment "Abstract certification of compliance according to given Certification Scheme." ;
+    rdfs:comment "Abstract certification of compliance according to given Certification Scheme."@en;
     idsm:abstract true .
 
 ids:CertificationScheme
     a owl:Class ;
     idsm:abstract true;
     rdfs:label "Certification Scheme"@en ;
-    rdfs:comment "Scheme defining the processes, roles, targets, and criteria involved in the certification of components and entities; maintained by the Certification Body." .
+    rdfs:comment "Scheme defining the processes, roles, targets, and criteria involved in the certification of components and entities; maintained by the Certification Body."@en.
 
 ids:CertificationLevel
     a owl:Class ;

--- a/model/governance/License.ttl
+++ b/model/governance/License.ttl
@@ -11,5 +11,5 @@
 ids:License rdfs:subClassOf dct:License;
     a owl:Class;
     rdfs:label "License"@en ;
-    rdfs:comment "Class of Licences to be referred to by Resources.".
+    rdfs:comment "Class of Licences to be referred to by Resources."@en.
 

--- a/model/infrastructure/Component.ttl
+++ b/model/infrastructure/Component.ttl
@@ -14,7 +14,7 @@ ids:InfrastructureComponent rdfs:subClassOf ids:ManagedEntity;
     a owl:Class;
     idsm:abstract true;
     rdfs:label "InfrastructureComponent"@en ;
-    rdfs:comment "The class of all infrastructure components of the IDS.";
+    rdfs:comment "The class of all infrastructure components of the IDS."@en;
     idsm:validation [
         idsm:forProperty ids:maintainer;
         idsm:constraint idsm:NotNull;

--- a/model/infrastructure/PublicKey.ttl
+++ b/model/infrastructure/PublicKey.ttl
@@ -13,7 +13,7 @@ ids:PublicKey a owl:Class ;
 
 ids:KeyType a owl:Class;
     rdfs:label "Key Type"@en ;
-    rdfs:comment "Cryptographic Key Type." ;
+    rdfs:comment "Cryptographic Key Type."@en ;
     idsm:abstract true.
 
 # Properties of InfrastructureComponent

--- a/model/security/AuthStandard.ttl
+++ b/model/security/AuthStandard.ttl
@@ -11,7 +11,7 @@
 
 ids:AuthStandard a owl:Class;
     rdfs:label "AuthStandard"@en ;
-    rdfs:comment "The class of authentication standards that may be supported by Connectors.".
+    rdfs:comment "The class of authentication standards that may be supported by Connectors."@en.
 
 # Instances
 # ---------

--- a/model/security/SecurityProfile.ttl
+++ b/model/security/SecurityProfile.ttl
@@ -16,7 +16,7 @@ ids:SecurityProfile a owl:Class;
 
 ids:CustomSecurityProfile a owl:Class;
     rdfs:label "CustomSecurityProfile"@en;
-    rdfs:comment "Specialized security profile that is composed of user-defined security guarantees";
+    rdfs:comment "Specialized security profile that is composed of user-defined security guarantees"@en;
     idsm:validation [
         idsm:forProperty ids:securityGuarantee;
         idsm:relationType idsm:OneToMany;

--- a/model/shared/Unit.ttl
+++ b/model/shared/Unit.ttl
@@ -8,5 +8,5 @@
 
 ids:Unit a owl:Class;
     rdfs:label "Unit"@en ;
-    rdfs:comment "Generic class of units used with quantifiable properties.".
+    rdfs:comment "Generic class of units used with quantifiable properties."@en.
 

--- a/model/traceability/ManagedEntity.ttl
+++ b/model/traceability/ManagedEntity.ttl
@@ -15,7 +15,7 @@ ids:ManagedEntity
     rdfs:subClassOf ids:Described ;
     idsm:abstract true;
     rdfs:label "Managed entity"@en ;
-    rdfs:comment "The class of mutable individuals that are a potential subject to lifecycle management which may need to be tracked.";
+    rdfs:comment "The class of mutable individuals that are a potential subject to lifecycle management which may need to be tracked."@en;
     idsm:validation [
         idsm:forProperty ids:lifecycleActivity;
         idsm:relationType idsm:OneToMany;

--- a/taxonomies/Certification.ttl
+++ b/taxonomies/Certification.ttl
@@ -10,14 +10,14 @@ ids:ParticipantCertificationLevel
     a owl:Class ;
     rdfs:subClassOf ids:CertificationLevel;
     rdfs:label "Participant Certification Level"@en ;
-    rdfs:comment "Level of a Participant Certification" .
+    rdfs:comment "Level of a Participant Certification"@en .
 
 ids:ComponentCertificationLevel
     a owl:Class ;
     rdfs:subClassOf ids:CertificationLevel;
     owl:disjointWith ids:ParticipantCertificationLevel ;
     rdfs:label "Component Certification Level"@en ;
-    rdfs:comment "Level of a Component Certification" .
+    rdfs:comment "Level of a Component Certification"@en .
 
 ids:ParticipantCertification
     a owl:Class ;
@@ -29,7 +29,7 @@ ids:ParticipantCertification
             owl:allValuesFrom ids:ParticipantCertificationLevel ;
         ] ;
     rdfs:label "Participant Certification"@en ;
-    rdfs:comment "Process and result of certifying an interested party in order to become a certified member of the International Data Space." .
+    rdfs:comment "Process and result of certifying an interested party in order to become a certified member of the International Data Space."@en.
 
 ids:ComponentCertification
     a owl:Class ;
@@ -42,7 +42,7 @@ ids:ComponentCertification
         ] ;
     owl:disjointWith ids:ParticipantCertification ;
     rdfs:label "Component Certification"@en ;
-    rdfs:comment "Process and result of certifying a software component/servivce in order to become a certified part of the International Data Space infrastructure." .
+    rdfs:comment "Process and result of certifying a software component/servivce in order to become a certified part of the International Data Space infrastructure."@en.
 
 # Properties
 # ----------

--- a/taxonomies/DigitalContent.ttl
+++ b/taxonomies/DigitalContent.ttl
@@ -31,21 +31,21 @@ ids:Audio a owl:Class;
     # language is optional
     rdfs:subClassOf ids:DigitalContent, dctype:Sound ;
     rdfs:label "Audio"@en ;
-    rdfs:comment "Content intended for auditive perception, requires an audio output device (i.e. a loudspeaker) to present the contents.";
+    rdfs:comment "Content intended for auditive perception, requires an audio output device (i.e. a loudspeaker) to present the contents."@en;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc2046#section-4.3> .
 
 ids:Image a owl:Class;
     rdfs:subClassOf ids:DigitalContent, dctype:StillImage ;
-    rdfs:label "Image";
-    rdfs:comment "Static content intended for visual perception/interpretation, requires a display device (i.e. a screen) to present the contents.";
+    rdfs:label "Image"@en;
+    rdfs:comment "Static content intended for visual perception/interpretation, requires a display device (i.e. a screen) to present the contents."@en;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc2046#section-4.2> .
 
 ids:Video
     # language is optional
     a owl:Class;
     rdfs:subClassOf ids:DigitalContent, dctype:MovingImage ;
-    rdfs:label "Video";
-    rdfs:comment "Dynamic content intended for visual and auditive perception, combines requirements of image and audio Content Types, while imposing further requirements on video decoding etc.";
+    rdfs:label "Video"@en;
+    rdfs:comment "Dynamic content intended for visual and auditive perception, combines requirements of image and audio Content Types, while imposing further requirements on video decoding etc."@en;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc2046#section-4.4> .
 
 ids:Software # .. or "Code" ?
@@ -59,14 +59,14 @@ ids:Software # .. or "Code" ?
 
 ids:Container a owl:Class;
    rdfs:subClassOf ids:DigitalContent, dctype:Collection ; # ISO-19115 "aggregate"; Multipart
-   rdfs:label "Container";
-   rdfs:comment "Container composed of multiple (individually defined) parts.";
+   rdfs:label "Container"@en;
+   rdfs:comment "Container composed of multiple (individually defined) parts."@en;
    rdfs:seeAlso <https://tools.ietf.org/html/rfc2046#section-5.1> ;
    .
 
 ids:OpaqueContent a owl:Class;
    rdfs:subClassOf ids:DigitalContent ;
-   rdfs:label "Opaque content";
+   rdfs:label "Opaque content"@en;
    rdfs:comment "Opaque, not further specified type of custom, binary content."@en ;  
    .
 

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -174,7 +174,7 @@ ids:queryLanguage a owl:ObjectProperty;
 ids:ContractRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
     rdfs:label "Contract Request Message"@en;
-    rdfs:comment "Message containing a suggested content contract (as offered by the data consumer to the data provider) in the associated payload (which is an instance of ContractRequest).";
+    rdfs:comment "Message containing a suggested content contract (as offered by the data consumer to the data provider) in the associated payload (which is an instance of ContractRequest)."@en;
     idsm:validation [
         idsm:forProperty ids:baseContractOffer;
         idsm:constraint idsm:NotNull;
@@ -190,7 +190,7 @@ ids:baseContractOffer a owl:ObjectProperty;
 ids:ContractOfferMessage a owl:Class ;
     rdfs:subClassOf ids:NotificationMessage ;
     rdfs:label "Contract Offer Message"@en;
-    rdfs:comment "Message containing a offered content contract (as offered by the data provider to the data consumer) in the associated payload (which is an instance of ContractOffer).".
+    rdfs:comment "Message containing a offered content contract (as offered by the data provider to the data consumer) in the associated payload (which is an instance of ContractOffer)."@en.
 
 ids:ContractAgreementMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage;

--- a/taxonomies/Representation.ttl
+++ b/taxonomies/Representation.ttl
@@ -48,7 +48,7 @@ ids:TextRepresentation a owl:Class;
 ids:AudioRepresentation a owl:Class;
     rdfs:subClassOf ids:Representation ;
     rdfs:label "Audio"@en ;
-    rdfs:comment "Audio representation" .
+    rdfs:comment "Audio representation"@en.
 
 ids:samplingRate a owl:DatatypeProperty;
     rdfs:domain ids:AudioRepresentation;
@@ -58,8 +58,8 @@ ids:samplingRate a owl:DatatypeProperty;
 
 ids:ImageRepresentation a owl:Class;
     rdfs:subClassOf ids:Representation ;
-    rdfs:label "Image";
-    rdfs:comment "Image representation" .
+    rdfs:label "Image"@en;
+    rdfs:comment "Image representation"@en.
 
 ids:width a owl:DatatypeProperty;
     rdfs:domain ids:ImageRepresentation;
@@ -75,8 +75,8 @@ ids:height a owl:DatatypeProperty;
 
 ids:VideoRepresentation a owl:Class;
     rdfs:subClassOf ids:ImageRepresentation ;
-    rdfs:label "Video";
-    rdfs:comment "Video representation" .
+    rdfs:label "Video"@en;
+    rdfs:comment "Video representation"@en.
 
 ids:frameRate a owl:DatatypeProperty;
     rdfs:domain ids:VideoRepresentation;


### PR DESCRIPTION
Added mssing **_\@<span></span>en_** language tags for all rdf:comment and rdf:label fields. Used the [tbox-shapes SHACL test](https://github.com/IndustrialDataSpace/InformationModel/tree/shacl/testing/shacl), written by @jpullmann, to find mssing language tags and validate corrected ontology. 