### PR TITLE
Recreated the three reference files. The vcard and org were directly …

### DIFF
--- a/model/participant/references/foaf-20140114.ttl
+++ b/model/participant/references/foaf-20140114.ttl
@@ -1,637 +1,686 @@
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix wot:   <http://xmlns.com/wot/0.1/> .
-@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix ns0: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-foaf:knows  a             rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A person known by this person (indicating some level of reciprocated interaction between the parties)." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "knows" ;
-        rdfs:range        foaf:Person ;
-        vs:term_status    "stable" .
+foaf:
+  a owl:Ontology ;
+  dc11:description "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language."^^xsd:string ;
+  dc11:title "Friend of a Friend (FOAF) vocabulary"^^xsd:string .
 
-foaf:firstName  a         rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The first name of a person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "firstName" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
+foaf:Agent
+  rdfs:isDefinedBy foaf: ;
+  a owl:Class, rdfs:Class ;
+  rdfs:comment "An agent (eg. person, group, software or physical artifact)."^^xsd:string ;
+  rdfs:label "Agent"^^xsd:string ;
+  owl:equivalentClass dc:Agent ;
+  ns0:term_status "stable"^^xsd:string .
 
-foaf:icqChatID  a           owl:InverseFunctionalProperty , rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment        "An ICQ chat ID" ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "ICQ chat ID" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  foaf:nick ;
-        vs:term_status      "testing" .
+foaf:Document
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A document."^^xsd:string ;
+  rdfs:label "Document"^^xsd:string ;
+  owl:disjointWith foaf:Organization, foaf:Project ;
+  ns0:term_status "testing"^^xsd:string .
 
-foaf:birthday  a          rdf:Property , owl:FunctionalProperty , owl:DatatypeProperty ;
-        rdfs:comment      "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "birthday" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "unstable" .
+foaf:Organization
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An organization."^^xsd:string ;
+  rdfs:label "Organization"^^xsd:string ;
+  rdfs:subClassOf foaf:Agent ;
+  owl:disjointWith foaf:Person, foaf:Document ;
+  ns0:term_status "stable"^^xsd:string .
 
-foaf:givenname  a         rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The given name of some person." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Given name" ;
-        vs:term_status    "archaic" .
+foaf:Project
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A project (a collective endeavour of some kind)."^^xsd:string ;
+  rdfs:label "Project"^^xsd:string ;
+  owl:disjointWith foaf:Person, foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
 
-foaf:focus  a             rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "The underlying or 'focal' entity associated with some SKOS-described concept." ;
-        rdfs:domain       <http://www.w3.org/2004/02/skos/core#Concept> ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "focus" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "testing" .
+foaf:Group
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A class of Agents."^^xsd:string ;
+  rdfs:label "Group"^^xsd:string ;
+  rdfs:subClassOf foaf:Agent ;
+  ns0:term_status "stable"^^xsd:string .
 
-foaf:phone  a             rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "phone" ;
-        vs:term_status    "testing" .
+foaf:Image
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An image."^^xsd:string ;
+  rdfs:label "Image"^^xsd:string ;
+  rdfs:subClassOf foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
 
-foaf:accountServiceHomepage
-        a                 rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "Indicates a homepage of the service provide for this online account." ;
-        rdfs:domain       foaf:OnlineAccount ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "account service homepage" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .
+foaf:LabelProperty
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A foaf:LabelProperty is any RDF property with texual values that serve as labels."^^xsd:string ;
+  rdfs:label "Label Property"^^xsd:string ;
+  ns0:term_status "unstable"^^xsd:string .
 
-foaf:givenName  a         rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The given name of some person." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Given name" ;
-        vs:term_status    "testing" .
-
-foaf:isPrimaryTopicOf
-        a                   owl:InverseFunctionalProperty , rdf:Property ;
-        rdfs:comment        "A document that this thing is the primary topic of." ;
-        rdfs:domain         owl:Thing ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "is primary topic of" ;
-        rdfs:range          foaf:Document ;
-        rdfs:subPropertyOf  foaf:page ;
-        owl:inverseOf       foaf:primaryTopic ;
-        vs:term_status      "stable" .
-
-foaf:openid  a              owl:ObjectProperty , rdf:Property , owl:InverseFunctionalProperty ;
-        rdfs:comment        "An OpenID for an Agent." ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "openid" ;
-        rdfs:range          foaf:Document ;
-        rdfs:subPropertyOf  foaf:isPrimaryTopicOf ;
-        vs:term_status      "testing" .
-
-foaf:depicts  a           rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A thing depicted in this representation." ;
-        rdfs:domain       foaf:Image ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "depicts" ;
-        rdfs:range        owl:Thing ;
-        owl:inverseOf     foaf:depiction ;
-        vs:term_status    "testing" .
-
-foaf:Project  a           rdfs:Class , owl:Class ;
-        rdfs:comment      "A project (a collective endeavour of some kind)." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Project" ;
-        owl:disjointWith  foaf:Person , foaf:Document ;
-        vs:term_status    "testing" .
-
-foaf:account  a           rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "Indicates an account held by this agent." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "account" ;
-        rdfs:range        foaf:OnlineAccount ;
-        vs:term_status    "testing" .
-
-foaf:skypeID  a             rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment        "A Skype ID" ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "Skype ID" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  foaf:nick ;
-        vs:term_status      "testing" .
-
-foaf:Image  a                rdfs:Class , owl:Class ;
-        rdfs:comment         "An image." ;
-        rdfs:isDefinedBy     foaf: ;
-        rdfs:label           "Image" ;
-        rdfs:subClassOf      foaf:Document ;
-        owl:equivalentClass  <http://schema.org/ImageObject> ;
-        vs:term_status       "stable" .
-
-foaf:page  a              rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A page or document about this thing." ;
-        rdfs:domain       owl:Thing ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "page" ;
-        rdfs:range        foaf:Document ;
-        owl:inverseOf     foaf:topic ;
-        vs:term_status    "stable" .
-
-foaf:OnlineEcommerceAccount
-        a                 rdfs:Class , owl:Class ;
-        rdfs:comment      "An online e-commerce account." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Online E-commerce Account" ;
-        rdfs:subClassOf   foaf:OnlineAccount ;
-        vs:term_status    "unstable" .
-
-foaf:lastName  a          rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The last name of a person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "lastName" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:homepage  a            rdf:Property , owl:ObjectProperty , owl:InverseFunctionalProperty ;
-        rdfs:comment        "A homepage for some thing." ;
-        rdfs:domain         owl:Thing ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "homepage" ;
-        rdfs:range          foaf:Document ;
-        rdfs:subPropertyOf  foaf:page , foaf:isPrimaryTopicOf ;
-        vs:term_status      "stable" .
-
-foaf:yahooChatID  a         owl:DatatypeProperty , rdf:Property , owl:InverseFunctionalProperty ;
-        rdfs:comment        "A Yahoo chat ID" ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "Yahoo chat ID" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  foaf:nick ;
-        vs:term_status      "testing" .
-
-foaf:membershipClass  a   rdf:Property , owl:AnnotationProperty ;
-        rdfs:comment      "Indicates the class of individuals that are a member of a Group" ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "membershipClass" ;
-        vs:term_status    "unstable" .
-
-wot:assurance  a  owl:AnnotationProperty .
-
-foaf:topic_interest  a    rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A thing of interest to this person." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "topic_interest" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "testing" .
-
-foaf:dnaChecksum  a       rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A checksum for the DNA of some thing. Joke." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "DNA checksum" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "archaic" .
-
-foaf:gender  a            rdf:Property , owl:FunctionalProperty , owl:DatatypeProperty ;
-        rdfs:comment      "The gender of this Agent (typically but not necessarily 'male' or 'female')." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "gender" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:mbox_sha1sum  a      rdf:Property , owl:InverseFunctionalProperty , owl:DatatypeProperty ;
-        rdfs:comment      "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "sha1sum of a personal mailbox URI name" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:logo  a              rdf:Property , owl:ObjectProperty , owl:InverseFunctionalProperty ;
-        rdfs:comment      "A logo representing some thing." ;
-        rdfs:domain       owl:Thing ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "logo" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "testing" .
-
-dc:description  a  owl:AnnotationProperty .
-
-foaf:img  a                 rdf:Property , owl:ObjectProperty ;
-        rdfs:comment        "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)." ;
-        rdfs:domain         foaf:Person ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "image" ;
-        rdfs:range          foaf:Image ;
-        rdfs:subPropertyOf  foaf:depiction ;
-        vs:term_status      "testing" .
-
-foaf:fundedBy  a          rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "An organization funding a project or person." ;
-        rdfs:domain       owl:Thing ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "funded by" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "archaic" .
-
-foaf:interest  a          rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A page about a topic of interest to this person." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "interest" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .
-
-<http://www.w3.org/2004/02/skos/core#Concept>
-        rdfs:label  "Concept" .
-
-foaf:familyName  a        rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The family name of some person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "familyName" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:status  a            rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A string expressing what the user is happy for the general public (normally) to know about their current activity." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "status" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "unstable" .
-
-foaf:msnChatID  a           owl:InverseFunctionalProperty , owl:DatatypeProperty , rdf:Property ;
-        rdfs:comment        "An MSN chat ID" ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "MSN chat ID" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  foaf:nick ;
-        vs:term_status      "testing" .
-
-foaf:sha1  a              rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A sha1sum hash, in hex." ;
-        rdfs:domain       foaf:Document ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "sha1sum (hex)" ;
-        vs:term_status    "unstable" .
-
-foaf:PersonalProfileDocument
-        a                rdfs:Class , owl:Class ;
-        rdfs:comment     "A personal profile RDF document." ;
-        rdfs:label       "PersonalProfileDocument" ;
-        rdfs:subClassOf  foaf:Document ;
-        vs:term_status   "testing" .
-
-foaf:workInfoHomepage
-        a                 rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A work info homepage of some person; a page about their work for some organization." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "work info homepage" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .
-
-foaf:currentProject  a    rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A current project this person works on." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "current project" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "testing" .
-
-foaf:mbox  a              rdf:Property , owl:InverseFunctionalProperty , owl:ObjectProperty ;
-        rdfs:comment      "A  personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "personal mailbox" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "stable" .
-
-vs:term_status  a  owl:AnnotationProperty .
-
-foaf:schoolHomepage  a    rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A homepage of a school attended by the person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "schoolHomepage" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .
-
-foaf:   a               owl:Ontology ;
-        dc:description  "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." ;
-        dc:title        "Friend of a Friend (FOAF) vocabulary" .
-
-owl:Thing  rdfs:label  "Thing" .
-
-foaf:Organization  a      rdfs:Class , owl:Class ;
-        rdfs:comment      "An organization." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Organization" ;
-        rdfs:subClassOf   foaf:Agent ;
-        owl:disjointWith  foaf:Person , foaf:Document ;
-        vs:term_status    "stable" .
-
-foaf:maker  a                   rdf:Property , owl:ObjectProperty ;
-        rdfs:comment            "An agent that  made this thing." ;
-        rdfs:domain             owl:Thing ;
-        rdfs:isDefinedBy        foaf: ;
-        rdfs:label              "maker" ;
-        rdfs:range              foaf:Agent ;
-        owl:equivalentProperty  <http://purl.org/dc/terms/creator> ;
-        owl:inverseOf           foaf:made ;
-        vs:term_status          "stable" .
-
-foaf:holdsAccount  a      rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "Indicates an account held by this agent." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "account" ;
-        rdfs:range        foaf:OnlineAccount ;
-        vs:term_status    "archaic" .
-
-foaf:jabberID  a          rdf:Property , owl:DatatypeProperty , owl:InverseFunctionalProperty ;
-        rdfs:comment      "A jabber ID for something." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "jabber ID" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
+foaf:OnlineAccount
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An online account."^^xsd:string ;
+  rdfs:label "Online Account"^^xsd:string ;
+  rdfs:subClassOf owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
 
 foaf:OnlineChatAccount
-        a                 rdfs:Class , owl:Class ;
-        rdfs:comment      "An online chat account." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Online Chat Account" ;
-        rdfs:subClassOf   foaf:OnlineAccount ;
-        vs:term_status    "unstable" .
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An online chat account."^^xsd:string ;
+  rdfs:label "Online Chat Account"^^xsd:string ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  ns0:term_status "unstable"^^xsd:string .
 
-foaf:pastProject  a       rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A project this person has previously worked on." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "past project" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "testing" .
-
-foaf:accountName  a       rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "Indicates the name (identifier) associated with this online account." ;
-        rdfs:domain       foaf:OnlineAccount ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "account name" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:name  a                rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment        "A name for some thing." ;
-        rdfs:domain         owl:Thing ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "name" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  rdfs:label ;
-        vs:term_status      "testing" .
-
-foaf:OnlineAccount  a     rdfs:Class , owl:Class ;
-        rdfs:comment      "An online account." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Online Account" ;
-        rdfs:subClassOf   owl:Thing ;
-        vs:term_status    "testing" .
-
-<http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing>
-        a           owl:Class ;
-        rdfs:label  "Spatial Thing" .
-
-wot:src_assurance  a  owl:AnnotationProperty .
-
-foaf:tipjar  a              rdf:Property , owl:ObjectProperty ;
-        rdfs:comment        "A tipjar document for this agent, describing means for payment and reward." ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "tipjar" ;
-        rdfs:range          foaf:Document ;
-        rdfs:subPropertyOf  foaf:page ;
-        vs:term_status      "testing" .
-
-foaf:Agent  a                owl:Class , rdfs:Class ;
-        rdfs:comment         "An agent (eg. person, group, software or physical artifact)." ;
-        rdfs:label           "Agent" ;
-        owl:equivalentClass  <http://purl.org/dc/terms/Agent> ;
-        vs:term_status       "stable" .
-
-rdfs:Class  a   owl:Class .
-
-foaf:myersBriggs  a       rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A Myers Briggs (MBTI) personality classification." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "myersBriggs" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:primaryTopic  a      owl:FunctionalProperty , rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "The primary topic of some page or document." ;
-        rdfs:domain       foaf:Document ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "primary topic" ;
-        rdfs:range        owl:Thing ;
-        owl:inverseOf     foaf:isPrimaryTopicOf ;
-        vs:term_status    "stable" .
-
-foaf:age  a               rdf:Property , owl:FunctionalProperty , owl:DatatypeProperty ;
-        rdfs:comment      "The age in years of some agent." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "age" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "unstable" .
-
-dc:date  a      owl:AnnotationProperty .
+foaf:OnlineEcommerceAccount
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An online e-commerce account."^^xsd:string ;
+  rdfs:label "Online E-commerce Account"^^xsd:string ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  ns0:term_status "unstable"^^xsd:string .
 
 foaf:OnlineGamingAccount
-        a                 rdfs:Class , owl:Class ;
-        rdfs:comment      "An online gaming account." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Online Gaming Account" ;
-        rdfs:subClassOf   foaf:OnlineAccount ;
-        vs:term_status    "unstable" .
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "An online gaming account."^^xsd:string ;
+  rdfs:label "Online Gaming Account"^^xsd:string ;
+  rdfs:subClassOf foaf:OnlineAccount ;
+  ns0:term_status "unstable"^^xsd:string .
 
-foaf:depiction  a         rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A depiction of some thing." ;
-        rdfs:domain       owl:Thing ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "depiction" ;
-        rdfs:range        foaf:Image ;
-        owl:inverseOf     foaf:depicts ;
-        vs:term_status    "testing" .
+foaf:Person
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A person."^^xsd:string ;
+  rdfs:label "Person"^^xsd:string ;
+  rdfs:subClassOf foaf:Agent, <http://www.w3.org/2000/10/swap/pim/contact#Person>, geo:SpatialThing ;
+  owl:disjointWith foaf:Organization, foaf:Project ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:PersonalProfileDocument
+  rdfs:isDefinedBy foaf: ;
+  a rdfs:Class, owl:Class ;
+  rdfs:comment "A personal profile RDF document."^^xsd:string ;
+  rdfs:label "PersonalProfileDocument"^^xsd:string ;
+  rdfs:subClassOf foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:account
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "Indicates an account held by this agent."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "account"^^xsd:string ;
+  rdfs:range foaf:OnlineAccount ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:accountName
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "Indicates the name (identifier) associated with this online account."^^xsd:string ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:label "account name"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:accountServiceHomepage
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "Indicates a homepage of the service provide for this online account."^^xsd:string ;
+  rdfs:domain foaf:OnlineAccount ;
+  rdfs:label "account service homepage"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:age
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  rdfs:comment "The age in years of some agent."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "age"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "unstable"^^xsd:string .
+
+foaf:aimChatID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "An AIM chat ID"^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "AIM chat ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf foaf:nick ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:nick
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)."^^xsd:string ;
+  rdfs:label "nickname"^^xsd:string ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:based_near
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A location that something is based near, for some broadly human notion of near."^^xsd:string ;
+  rdfs:domain geo:SpatialThing ;
+  rdfs:label "based near"^^xsd:string ;
+  rdfs:range geo:SpatialThing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:birthday
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  rdfs:comment "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "birthday"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "unstable"^^xsd:string .
+
+foaf:currentProject
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A current project this person works on."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "current project"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:depiction
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A depiction of some thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "depiction"^^xsd:string ;
+  rdfs:range foaf:Image ;
+  owl:inverseOf foaf:depicts ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:depicts
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A thing depicted in this representation."^^xsd:string ;
+  rdfs:domain foaf:Image ;
+  rdfs:label "depicts"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:depiction ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:dnaChecksum
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A checksum for the DNA of some thing. Joke."^^xsd:string ;
+  rdfs:label "DNA checksum"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:familyName
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The family name of some person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "familyName"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:family_name
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The family name of some person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "family_name"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:firstName
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The first name of a person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "firstName"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:focus
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "The underlying or 'focal' entity associated with some SKOS-described concept."^^xsd:string ;
+  rdfs:domain skos:Concept ;
+  rdfs:label "focus"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:fundedBy
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "An organization funding a project or person."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "funded by"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:geekcode
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A textual geekcode for this person, see http://www.geekcode.com/geek.html"^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "geekcode"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:gender
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:FunctionalProperty, owl:DatatypeProperty ;
+  rdfs:comment "The gender of this Agent (typically but not necessarily 'male' or 'female')."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "gender"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:givenName
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The given name of some person."^^xsd:string ;
+  rdfs:label "Given name"^^xsd:string ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:givenname
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The given name of some person."^^xsd:string ;
+  rdfs:label "Given name"^^xsd:string ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:holdsAccount
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "Indicates an account held by this agent."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "account"^^xsd:string ;
+  rdfs:range foaf:OnlineAccount ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:homepage
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "A homepage for some thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "homepage"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:page, foaf:isPrimaryTopicOf ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:page
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A page or document about this thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "page"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  owl:inverseOf foaf:topic ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:isPrimaryTopicOf
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:InverseFunctionalProperty ;
+  rdfs:comment "A document that this thing is the primary topic of."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "is primary topic of"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:page ;
+  owl:inverseOf foaf:primaryTopic ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:icqChatID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "An ICQ chat ID"^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "ICQ chat ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf foaf:nick ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:img
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "image"^^xsd:string ;
+  rdfs:range foaf:Image ;
+  rdfs:subPropertyOf foaf:depiction ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:interest
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A page about a topic of interest to this person."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "interest"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:primaryTopic
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:FunctionalProperty, owl:ObjectProperty ;
+  rdfs:comment "The primary topic of some page or document."^^xsd:string ;
+  rdfs:domain foaf:Document ;
+  rdfs:label "primary topic"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:isPrimaryTopicOf ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:jabberID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "A jabber ID for something."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "jabber ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:knows
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A person known by this person (indicating some level of reciprocated interaction between the parties)."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "knows"^^xsd:string ;
+  rdfs:range foaf:Person ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:lastName
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The last name of a person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "lastName"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:logo
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "A logo representing some thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "logo"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:made
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "Something that was made by this agent."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "made"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:maker ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:maker
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "An agent that made this thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "maker"^^xsd:string ;
+  rdfs:range foaf:Agent ;
+  owl:equivalentProperty dc:creator ;
+  owl:inverseOf foaf:made ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:mbox
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:InverseFunctionalProperty, owl:ObjectProperty ;
+  rdfs:comment "A personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that there is (across time and change) at most one individual that ever has any particular value for foaf:mbox."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "personal mailbox"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:mbox_sha1sum
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:InverseFunctionalProperty, owl:DatatypeProperty ;
+  rdfs:comment "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the first owner of the mailbox."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "sha1sum of a personal mailbox URI name"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:member
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "Indicates a member of a Group"^^xsd:string ;
+  rdfs:domain foaf:Group ;
+  rdfs:label "member"^^xsd:string ;
+  rdfs:range foaf:Agent ;
+  ns0:term_status "stable"^^xsd:string .
+
+foaf:membershipClass
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:AnnotationProperty ;
+  rdfs:comment "Indicates the class of individuals that are a member of a Group"^^xsd:string ;
+  rdfs:label "membershipClass"^^xsd:string ;
+  ns0:term_status "unstable"^^xsd:string .
+
+foaf:msnChatID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "An MSN chat ID"^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "MSN chat ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf foaf:nick ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:myersBriggs
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A Myers Briggs (MBTI) personality classification."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "myersBriggs"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:name
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A name for some thing."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "name"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf rdfs:label ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:openid
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "An OpenID for an Agent."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "openid"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:isPrimaryTopicOf ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:topic
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A topic of some page or document."^^xsd:string ;
+  rdfs:domain foaf:Document ;
+  rdfs:label "topic"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  owl:inverseOf foaf:page ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:pastProject
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A project this person has previously worked on."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "past project"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:phone
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A phone, specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)."^^xsd:string ;
+  rdfs:label "phone"^^xsd:string ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:plan
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A .plan comment, in the tradition of finger and '.plan' files."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "plan"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:publications
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A link to the publications of this person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "publications"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:schoolHomepage
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A homepage of a school attended by the person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "schoolHomepage"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:sha1
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A sha1sum hash, in hex."^^xsd:string ;
+  rdfs:domain foaf:Document ;
+  rdfs:label "sha1sum (hex)"^^xsd:string ;
+  ns0:term_status "unstable"^^xsd:string .
+
+foaf:skypeID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A Skype ID"^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "Skype ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf foaf:nick ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:status
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "A string expressing what the user is happy for the general public (normally) to know about their current activity."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "status"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "unstable"^^xsd:string .
+
+foaf:surname
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "The surname of some person."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "Surname"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:theme
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A theme."^^xsd:string ;
+  rdfs:domain owl:Thing ;
+  rdfs:label "theme"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "archaic"^^xsd:string .
+
+foaf:thumbnail
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A derived thumbnail image."^^xsd:string ;
+  rdfs:domain foaf:Image ;
+  rdfs:label "thumbnail"^^xsd:string ;
+  rdfs:range foaf:Image ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:tipjar
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A tipjar document for this agent, describing means for payment and reward."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "tipjar"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:page ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:title
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty ;
+  rdfs:comment "Title (Mr, Mrs, Ms, Dr. etc)"^^xsd:string ;
+  rdfs:label "title"^^xsd:string ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:topic_interest
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A thing of interest to this person."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "topic_interest"^^xsd:string ;
+  rdfs:range owl:Thing ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:weblog
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "A weblog of some thing (whether person, group, company etc.)."^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "weblog"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:page ;
+  ns0:term_status "testing"^^xsd:string .
+
+foaf:workInfoHomepage
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A work info homepage of some person; a page about their work for some organization."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "work info homepage"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
 
 foaf:workplaceHomepage
-        a                 rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A workplace homepage of some person; the homepage of an organization they work for." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "workplace homepage" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:comment "A workplace homepage of some person; the homepage of an organization they work for."^^xsd:string ;
+  rdfs:domain foaf:Person ;
+  rdfs:label "workplace homepage"^^xsd:string ;
+  rdfs:range foaf:Document ;
+  ns0:term_status "testing"^^xsd:string .
 
-foaf:title  a             rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "Title (Mr, Mrs, Ms, Dr. etc)" ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "title" ;
-        vs:term_status    "testing" .
+foaf:yahooChatID
+  rdfs:isDefinedBy foaf: ;
+  a rdf:Property, owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+  rdfs:comment "A Yahoo chat ID"^^xsd:string ;
+  rdfs:domain foaf:Agent ;
+  rdfs:label "Yahoo chat ID"^^xsd:string ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf foaf:nick ;
+  ns0:term_status "testing"^^xsd:string .
 
-foaf:weblog  a              rdf:Property , owl:InverseFunctionalProperty , owl:ObjectProperty ;
-        rdfs:comment        "A weblog of some thing (whether person, group, company etc.)." ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "weblog" ;
-        rdfs:range          foaf:Document ;
-        rdfs:subPropertyOf  foaf:page ;
-        vs:term_status      "stable" .
-
-foaf:thumbnail  a         rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A derived thumbnail image." ;
-        rdfs:domain       foaf:Image ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "thumbnail" ;
-        rdfs:range        foaf:Image ;
-        vs:term_status    "testing" .
-
-foaf:Person  a               rdfs:Class , owl:Class ;
-        rdfs:comment         "A person." ;
-        rdfs:isDefinedBy     foaf: ;
-        rdfs:label           "Person" ;
-        rdfs:subClassOf      <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> , foaf:Agent ;
-        owl:disjointWith     foaf:Project , foaf:Organization ;
-        owl:equivalentClass  <http://schema.org/Person> , <http://www.w3.org/2000/10/swap/pim/contact#Person> ;
-        vs:term_status       "stable" .
-
-foaf:nick  a              rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "nickname" ;
-        vs:term_status    "testing" .
-
-foaf:LabelProperty  a     rdfs:Class , owl:Class ;
-        rdfs:comment      "A foaf:LabelProperty is any RDF property with texual values that serve as labels." ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Label Property" ;
-        vs:term_status    "unstable" .
-
-foaf:made  a              rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "Something that was made by this agent." ;
-        rdfs:domain       foaf:Agent ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "made" ;
-        rdfs:range        owl:Thing ;
-        owl:inverseOf     foaf:maker ;
-        vs:term_status    "stable" .
-
-foaf:based_near  a        rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A location that something is based near, for some broadly human notion of near." ;
-        rdfs:domain       <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "based near" ;
-        rdfs:range        <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
-        vs:term_status    "testing" .
-
-foaf:surname  a           rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The surname of some person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "Surname" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "archaic" .
-
-foaf:plan  a              rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A .plan comment, in the tradition of finger and '.plan' files." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "plan" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "testing" .
-
-foaf:aimChatID  a           rdf:Property , owl:DatatypeProperty , owl:InverseFunctionalProperty ;
-        rdfs:comment        "An AIM chat ID" ;
-        rdfs:domain         foaf:Agent ;
-        rdfs:isDefinedBy    foaf: ;
-        rdfs:label          "AIM chat ID" ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  foaf:nick ;
-        vs:term_status      "testing" .
-
-foaf:Group  a            rdfs:Class , owl:Class ;
-        rdfs:comment     "A class of Agents." ;
-        rdfs:label       "Group" ;
-        rdfs:subClassOf  foaf:Agent ;
-        vs:term_status   "stable" .
-
-foaf:geekcode  a          rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "A textual geekcode for this person, see http://www.geekcode.com/geek.html" ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "geekcode" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "archaic" .
-
-dc:title  a     owl:AnnotationProperty .
-
-foaf:Document  a             rdfs:Class , owl:Class ;
-        rdfs:comment         "A document." ;
-        rdfs:isDefinedBy     foaf: ;
-        rdfs:label           "Document" ;
-        owl:disjointWith     foaf:Organization , foaf:Project ;
-        owl:equivalentClass  <http://schema.org/CreativeWork> ;
-        vs:term_status       "stable" .
-
-foaf:family_name  a       rdf:Property , owl:DatatypeProperty ;
-        rdfs:comment      "The family name of some person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "family_name" ;
-        rdfs:range        rdfs:Literal ;
-        vs:term_status    "archaic" .
-
-foaf:topic  a             rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A topic of some page or document." ;
-        rdfs:domain       foaf:Document ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "topic" ;
-        rdfs:range        owl:Thing ;
-        owl:inverseOf     foaf:page ;
-        vs:term_status    "testing" .
-
-foaf:member  a            rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "Indicates a member of a Group" ;
-        rdfs:domain       foaf:Group ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "member" ;
-        rdfs:range        foaf:Agent ;
-        vs:term_status    "stable" .
-
-foaf:theme  a             rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A theme." ;
-        rdfs:domain       owl:Thing ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "theme" ;
-        rdfs:range        owl:Thing ;
-        vs:term_status    "archaic" .
-
-foaf:publications  a      rdf:Property , owl:ObjectProperty ;
-        rdfs:comment      "A link to the publications of this person." ;
-        rdfs:domain       foaf:Person ;
-        rdfs:isDefinedBy  foaf: ;
-        rdfs:label        "publications" ;
-        rdfs:range        foaf:Document ;
-        vs:term_status    "testing" .


### PR DESCRIPTION
…downloaded from www.w3.org/2006/vcard/ns# and www.w3.org/ns/org# respectively. The foaf file, which contained bad triples, was downloaded from http://xmlns.com/foaf/spec/20140114.rdf and then transformed to turtle by using the open-source converter http://www.easyrdf.org/converter


Refers to Issue #99