### PR TITLE
Feat raw shacl links

### DIFF
--- a/metamodel/Annotation.ttl
+++ b/metamodel/Annotation.ttl
@@ -27,13 +27,14 @@ idsm:referenceByUri
 # - generic domain rdfs:Resource applies to any classes and predicates
 # - language-tagged text, rdf:PlainLiteral
 
-idsm:labelPluralForm
-    a owl:DatatypeProperty;
-    rdfs:subPropertyOf skos:prefLabel;
-    rdfs:label "plural label form"@en;
-    rdfs:domain rdfs:Resource;
-    rdfs:range rdf:PlainLiteral;
-    rdfs:comment "The preferred lexical label for a resource, in plural form in a given language."@en.
+# bad practice for RDF properties
+#idsm:labelPluralForm
+#    a owl:DatatypeProperty;
+#    rdfs:subPropertyOf skos:prefLabel;
+#    rdfs:label "plural label form"@en;
+#    rdfs:domain rdfs:Resource;
+#    rdfs:range rdf:PlainLiteral;
+#    rdfs:comment "The preferred lexical label for a resource, in plural form in a given language."@en.
 
 idsm:example
     a owl:DatatypeProperty;

--- a/model/communication/Message.ttl
+++ b/model/communication/Message.ttl
@@ -77,7 +77,6 @@ ids:recipientConnector
     a owl:ObjectProperty;
     idsm:referenceByUri true;
     rdfs:label "recipient connector"@en;
-    idsm:labelPluralForm "recipientConnectors"@en;
     rdfs:domain ids:Message;
     rdfs:range ids:Connector;
     rdfs:comment "The Connector which is the recipient of the message."@en.
@@ -94,7 +93,6 @@ ids:recipientAgent
     a owl:DatatypeProperty;
     idsm:referenceByUri true;
     rdfs:label "recipient agent"@en;
-    idsm:labelPluralForm "recipientAgents"@en;
     rdfs:domain ids:Message;
     rdfs:range ids:Agent;
     rdfs:comment "The Agent for which the Mesaage is intended."@en.

--- a/model/communication/Operation.ttl
+++ b/model/communication/Operation.ttl
@@ -48,7 +48,6 @@ ids:input a owl:ObjectProperty;
     rdfs:domain ids:Operation;
     rdfs:range ids:Parameter;
     rdfs:label "input"@en;
-    idsm:labelPluralForm "inputs"@en;
     rdfs:comment "Reference to an input Parameter (optionaly) used by the Operation."@en.
 
 ids:mandatoryInput
@@ -57,7 +56,6 @@ ids:mandatoryInput
     rdfs:domain ids:Operation;
     rdfs:range ids:Parameter;
     rdfs:label "mandatoryInput"@en;
-    idsm:labelPluralForm "mandatoryInputs"@en;
     rdfs:comment "Reference to an input Parameter required by the Operation."@en.
 
 ids:inputGroup a owl:ObjectProperty;
@@ -76,7 +74,6 @@ ids:output a owl:ObjectProperty;
     rdfs:domain ids:Operation;
     rdfs:range ids:Parameter;
     rdfs:label "output"@en;
-    idsm:labelPluralForm "outputs"@en;
     rdfs:comment "Holds the result of an Operation."@en.
 
 ids:mandatoryOutput a owl:ObjectProperty;
@@ -84,14 +81,12 @@ ids:mandatoryOutput a owl:ObjectProperty;
     rdfs:domain ids:Operation;
     rdfs:range ids:Parameter;
     rdfs:label "mandatoryOutput"@en;
-    idsm:labelPluralForm "mandatoryOutputs"@en;
     rdfs:comment "Holds the mandatory result of an Operation."@en.
 
 ids:fault a owl:ObjectProperty;
     rdfs:domain ids:Operation;
     rdfs:range ids:Parameter;
     rdfs:label "fault"@en;
-    idsm:labelPluralForm "faults"@en;
     rdfs:comment "Holds information when an Operation has failed."@en.
 
 # TODO: Replace by general annotation
@@ -100,7 +95,6 @@ ids:fault a owl:ObjectProperty;
 #    a owl:DatatypeProperty;
 #    rdfs:domain ids:Operation;
 #    rdfs:range rdf:PlainLiteral;
-#    idsm:labelPluralForm "operationLabels"@en;
 #    rdfs:label "Operation Label"@en;
 #    rdfs:comment "Freetext label of the Operation as it should be shown in public indexes."@en.
 
@@ -108,7 +102,6 @@ ids:fault a owl:ObjectProperty;
 #    a owl:DatatypeProperty;
 #    rdfs:domain ids:Operation;
 #    rdfs:range rdf:PlainLiteral;
-#    idsm:labelPluralForm "operationDescriptions"@en;
 #    rdfs:label "Operation Description"@en;
 #    rdfs:comment "Freetext description of the Operation as it should be shown in public indexes."@en.
 

--- a/model/communication/ParameterGroup.ttl
+++ b/model/communication/ParameterGroup.ttl
@@ -29,7 +29,6 @@ ids:paramGroupMember a owl:ObjectProperty;
     rdfs:domain ids:ParameterGroup;
     rdfs:range ids:Parameter;
     rdfs:label "paramGroupMember"@en;
-    idsm:labelPluralForm "paramGroupMembers"@en;
     rdfs:comment "Declares a member of a ParameterGroup."@en.
 
 ids:paramGroupingOperator a owl:ObjectProperty;

--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -72,7 +72,6 @@ ids:contentPart
     a owl:ObjectProperty;
     rdfs:subPropertyOf dct:hasPart;
     rdfs:label "content part"@en;
-    idsm:labelPluralForm "contentParts"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:DigitalContent;
     rdfs:comment "Reference to a Digital Content (physically or logically) included, definition of part-whole hierarchies."@en .
@@ -81,7 +80,6 @@ ids:representation
     a owl:ObjectProperty;
     #rdfs:subPropertyOf dcat:distribution ; # Links to non-materialized part of Distribution
     rdfs:label "representation"@en;
-    idsm:labelPluralForm "representations"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:Representation;
     rdfs:comment "Representation of the content."@en.
@@ -100,7 +98,6 @@ ids:language
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:Language; # does not fit the defined range of dct:language - dct:LinguisticSystem !
     rdfs:label "language"@en;
-    idsm:labelPluralForm "languages"@en;
     rdfs:comment "Natural language(s) used within the content."@en.
 
 ids:theme # ... "topic" / "subject" ?
@@ -108,7 +105,6 @@ ids:theme # ... "topic" / "subject" ?
     rdfs:subPropertyOf dcat:theme; # is a sub-property of dct:subject, comparable to qb:concept (?)
     idsm:referenceByUri true ;
     rdfs:label "theme"@en;
-    idsm:labelPluralForm "themes"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:Concept; # former "ContentCategory", skos:Concepts organized in a skos:ConceptScheme
     rdfs:comment "Abstract or concrete concept related to or referred by the content."@en.
@@ -118,7 +114,6 @@ ids:keyword
     a owl:DatatypeProperty;
     rdfs:subPropertyOf dcat:keyword;
     rdfs:label "keyword"@en;
-    idsm:labelPluralForm "keywords"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range rdfs:Literal;
     rdfs:comment "Controlled keywords that describe the nature, purpose, or use of the content."@en.
@@ -127,7 +122,6 @@ ids:temporalCoverage
     a owl:ObjectProperty;
     rdfs:subPropertyOf dct:temporal;
     rdfs:label "temporal coverage"@en;
-    idsm:labelPluralForm "temporalCoverages"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:TemporalEntity;
     rdfs:comment "Temporal period or instance covered by the content."@en.
@@ -136,7 +130,6 @@ ids:spatialCoverage
     a owl:ObjectProperty;
     rdfs:subPropertyOf dct:spatial;
     rdfs:label "spatial coverage"@en;
-    idsm:labelPluralForm "spatialCoverages"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:SpatialEntity;
     rdfs:comment "Named spatial entity covered by the Resource."@en.

--- a/model/content/Representation.ttl
+++ b/model/content/Representation.ttl
@@ -43,7 +43,6 @@ ids:instance
     rdfs:domain ids:Representation ;
     rdfs:range ids:RepresentationInstance;
     rdfs:label "instance"@en ;
-    idsm:labelPluralForm "instances"@en;
     rdfs:comment "Reference to an instance of given representation, i.e. inline value or file placeholder."@en.
 
 ids:mediaType

--- a/model/content/Resource.ttl
+++ b/model/content/Resource.ttl
@@ -12,9 +12,8 @@
 
 ids:Resource
     a owl:Class;
-    rdfs:subClassOf
-        ids:Described, ids:DigitalContent, # e.g. Collection Resource contains sub-resources but also has an own Representation
-        dcat:Dataset, ids:ManagedEntity;
+    rdfs:subClassOf ids:DigitalContent, # e.g. Collection Resource contains sub-resources but also has an own Representation
+        ids:ManagedEntity;
     rdfs:label "Resource"@en ;
     rdfs:comment "Resource is a single digital content or a coherent set of digital contents. Resource content is formalized in Representations and optionally materialized as Artifacts. The Resource's content is exposed via defined Interfaces at various protocol Endpoints."@en;
     rdfs:seeAlso <https://www.w3.org/TR/vocab-dcat/#class-dataset>;
@@ -54,7 +53,6 @@ ids:Resource
 ids:resourcePart a owl:ObjectProperty;
     rdfs:subPropertyOf ids:contentPart;
     rdfs:label "resource part"@en;
-    idsm:labelPluralForm "resourceParts"@en;
     rdfs:domain ids:Resource;
     rdfs:range ids:Resource;
     rdfs:comment "Reference to a Resource (physically or logically) included, definition of part-whole hierarchies."@en .
@@ -69,7 +67,6 @@ ids:resourceInterface
 ids:resourceEndpoint
     a owl:ObjectProperty;
     rdfs:label "resource endpoint"@en;
-    idsm:labelPluralForm "resourceEndpoints"@en;
     rdfs:domain ids:Resource;
     rdfs:range ids:Endpoint;
     rdfs:comment "Reference to the Endpoints serving the resource's content."@en.
@@ -96,7 +93,6 @@ ids:contractOffer
     rdfs:domain ids:Resource;
     rdfs:range ids:ContractOffer;
     rdfs:label "contract offer"@en;
-    idsm:labelPluralForm "contractOffers"@en;
     rdfs:comment "Reference to a Contract Offer defining the authorized use of the Resource."@en.
 
 ids:publisher
@@ -117,7 +113,6 @@ ids:sovereign
 ids:sample a owl:ObjectProperty;
     # dicuss: rdfs:subPropertyOf and range
     rdfs:label "sample"@en;
-    idsm:labelPluralForm "samples"@en;
     rdfs:domain ids:Resource;
     rdfs:range ids:Resource;# Web-retrievable or inline content
     rdfs:comment "Sample Resource instance."@en.

--- a/model/context/SpatialEntity.ttl
+++ b/model/context/SpatialEntity.ttl
@@ -81,6 +81,5 @@ ids:geoPoint a owl:ObjectProperty;
      rdfs:domain ids:BoundingPolygon;
      rdfs:range ids:GeoPoint;
      rdfs:label "geoPoint"@en;
-     idsm:labelPluralForm "geoPoints"@en;
      rdfs:comment "Refers to a GeoPoint that is member of a BoundingPolygon."@en.
 

--- a/model/contract/Action.ttl
+++ b/model/contract/Action.ttl
@@ -27,7 +27,6 @@ ids:actionRefinement
     a owl:ObjectProperty;
     # rdfs:subPropertyOf odrl:refinement ;
     rdfs:label "action refinement"@en;
-    idsm:labelPluralForm "actionRefinements"@en;
     rdfs:domain ids:Action;
     rdfs:range ids:Constraint;
     rdfs:comment "Constraint that refines an Action."@en.

--- a/model/contract/Contract.ttl
+++ b/model/contract/Contract.ttl
@@ -111,7 +111,6 @@ ids:contractAnnex a owl:ObjectProperty;
 ids:permission rdfs:subPropertyOf odrl:permission;
     a owl:ObjectProperty;
     rdfs:label "permission"@en;
-    idsm:labelPluralForm "permissions"@en;
     rdfs:domain ids:Contract;
     rdfs:range ids:Permission;
     rdfs:comment "A Permission granted by the Contract."@en.
@@ -119,7 +118,6 @@ ids:permission rdfs:subPropertyOf odrl:permission;
 ids:prohibition rdfs:subPropertyOf odrl:prohibition;
     a owl:ObjectProperty;
     rdfs:label "prohibition"@en;
-    idsm:labelPluralForm "prohibitions"@en;
     rdfs:domain ids:Contract;
     rdfs:range ids:Prohibition;
     rdfs:comment "A Prohibition imposed by the Contract."@en.
@@ -127,7 +125,6 @@ ids:prohibition rdfs:subPropertyOf odrl:prohibition;
 ids:obligation rdfs:subPropertyOf odrl:obligation;
     a owl:ObjectProperty;
     rdfs:label "obligation"@en;
-    idsm:labelPluralForm "obligations"@en;
     rdfs:domain ids:Contract;
     rdfs:range ids:Duty;
     rdfs:comment "A Duty imposed by the Contract."@en.

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -67,7 +67,6 @@ ids:action
     rdfs:subPropertyOf odrl:action;
     a owl:ObjectProperty;
     rdfs:label "action"@en;
-    idsm:labelPluralForm "actions"@en;
     rdfs:domain ids:Rule;
     rdfs:range ids:Action;
     rdfs:comment "The operation relating to the asset for which permission is being granted."@en.
@@ -77,7 +76,6 @@ ids:assignee rdfs:subPropertyOf odrl:assignee;
     rdfs:domain ids:Rule;
     rdfs:range ids:Participant;
     rdfs:label "assignee"@en;
-    idsm:labelPluralForm "assignees"@en;
     rdfs:comment "The recipient of the policy statement."@en.
 
 # "all X but ..."
@@ -92,7 +90,6 @@ ids:assigner rdfs:subPropertyOf odrl:assigner;
     rdfs:domain ids:Rule;
     rdfs:range ids:Participant;
     rdfs:label "assigner"@en;
-    idsm:labelPluralForm "assigners"@en;
     rdfs:comment "The issuer of the policy statement."@en.
 
 ids:targetArtifact
@@ -113,7 +110,6 @@ ids:targetContent
 ids:duty rdfs:subPropertyOf odrl:duty;
     a owl:ObjectProperty;
     rdfs:label "duty"@en;
-    idsm:labelPluralForm "duties"@en;
     rdfs:domain ids:Permission;
     rdfs:range ids:Duty;
     rdfs:comment "The Duties imposed by a Permission."@en.
@@ -121,7 +117,6 @@ ids:duty rdfs:subPropertyOf odrl:duty;
 ids:constraint rdfs:subPropertyOf odrl:constraint;
     a owl:ObjectProperty;
     rdfs:label "constraint"@en;
-    idsm:labelPluralForm "constraints"@en;
     rdfs:domain ids:Rule;
     rdfs:range ids:Constraint;
     rdfs:comment "The constraint to be used for a specific rule."@en.
@@ -130,7 +125,6 @@ ids:contentRefinement
     a owl:ObjectProperty;
     # rdfs:subPropertyOf odrl:refinement ;
     rdfs:label "content refinement"@en;
-    idsm:labelPluralForm "contentRefinements"@en;
     rdfs:domain ids:DigitalContent;
     rdfs:range ids:Constraint;
     rdfs:comment "Constraint that refines a (composite) Digital Content."@en.

--- a/model/infrastructure/Broker.ttl
+++ b/model/infrastructure/Broker.ttl
@@ -20,7 +20,6 @@ ids:Broker
 ids:connector a owl:ObjectProperty;
     idsm:referenceByUri true;
     rdfs:label "connector"@en;
-    idsm:labelPluralForm "connectors"@en;
     rdfs:domain ids:Broker;
     rdfs:range ids:Connector;
     rdfs:comment "Reference to a Connector listed in the Broker."@en.

--- a/model/infrastructure/Catalog.ttl
+++ b/model/infrastructure/Catalog.ttl
@@ -30,13 +30,11 @@ ids:offer a owl:ObjectProperty;
     rdfs:domain ids:Catalog;
     rdfs:range ids:Resource;
     rdfs:label "offer"@en;
-    idsm:labelPluralForm "offers"@en;
     rdfs:comment "A Resource that is part of a Connector, indicating a offering (of, e.g., data)."@en.
 
 ids:request a owl:ObjectProperty;
     rdfs:domain ids:Catalog;
     rdfs:range ids:Resource;
     rdfs:label "request"@en;
-    idsm:labelPluralForm "requests"@en;
     rdfs:comment "A Resource that is part of a Connector, indicating a request (of, e.g., data, software,...)."@en.
 

--- a/model/infrastructure/InfrastructureComponent.ttl
+++ b/model/infrastructure/InfrastructureComponent.ttl
@@ -59,7 +59,6 @@ ids:physicalLocation a owl:ObjectProperty;
 
 ids:inboundModelVersion a owl:DatatypeProperty;
     rdfs:label "inboundModelVersion"@en;
-    idsm:labelPluralForm "inboundModelVersions"@en;
     rdfs:domain ids:InfrastructureComponent;
     rdfs:range xsd:string;
     rdfs:comment "Information Model version that the InfrastructureComponent is capable of reading/processing."@en.

--- a/model/participant/Participant.ttl
+++ b/model/participant/Participant.ttl
@@ -69,7 +69,6 @@ ids:primarySite rdfs:subPropertyOf org:hasPrimarySite;
 
 ids:corporateEmailAddress rdfs:subPropertyOf foaf:mbox;
     a owl:DatatypeProperty;
-    idsm:labelPluralForm "corporateEmailAddresses"@en;
     rdfs:label "corporateEmailAddress"@en;
     rdfs:domain ids:Participant;
     rdfs:range xsd:string;
@@ -86,13 +85,11 @@ ids:memberParticipant rdfs:subPropertyOf org:hasMember;
     a owl:ObjectProperty;
     rdfs:domain ids:Participant;
     rdfs:range ids:Participant;
-    idsm:labelPluralForm "memberParticipants"@en;
     rdfs:label "member participant"@en;
     rdfs:comment "Indicates that a participant has a member which is again a participant. This is useful for defining hierarchical relations in a participant's organization as well as identifying groups of participants to capture, e.g., members of a collaboration."@en.
 
 ids:industrialClassification a owl:ObjectProperty;
     rdfs:label "industrial classification"@en;
-    idsm:labelPluralForm "industrialClassifications"@en;
     rdfs:domain ids:Participant;
     rdfs:range ids:IndustrialClassification;
     rdfs:comment "Industry branch covered by the Participant."@en.
@@ -112,7 +109,6 @@ ids:memberPerson rdfs:subPropertyOf org:hasMember;
     a owl:ObjectProperty;
     rdfs:domain ids:Participant;
     rdfs:range ids:Person;
-    idsm:labelPluralForm "memberPersons"@en;
     rdfs:label "memberPerson"@en;
     rdfs:comment "Indicates membership of a person to an organization."@en.
 
@@ -134,7 +130,6 @@ ids:phoneNumber rdfs:subPropertyOf foaf:phone;
     a owl:DatatypeProperty;
     rdfs:domain ids:Person;
     rdfs:range xsd:string;
-    idsm:labelPluralForm "phoneNumbers"@en;
     rdfs:label "phoneNumber"@en;
     rdfs:comment "Phone number of a person."@en.
 
@@ -142,7 +137,6 @@ ids:emailAddress rdfs:subPropertyOf foaf:mbox;
     a owl:DatatypeProperty;
     rdfs:domain ids:Person;
     rdfs:range xsd:string;
-    idsm:labelPluralForm "emailAddresses"@en;
     rdfs:label "emailAddress"@en;
     rdfs:comment "Email contact of a person."@en.
 

--- a/model/security/SecurityProfile.ttl
+++ b/model/security/SecurityProfile.ttl
@@ -14,9 +14,9 @@ ids:SecurityProfile a owl:Class;
     idsm:validation [
         idsm:forProperty ids:securityGuarantee;
         idsm:relationType idsm:OneToMany;
-    ].
+    ];
     # .. specifies several security aspects expressing the minimum requirements a Data Consumer must meet to be granted access to the Data Endpoints exposed by a providing Connector.
-
+    .
 
 ids:SecurityGuarantee
     a owl:Class;

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -90,14 +90,14 @@ ids:sub a owl:DatatypeProperty;
 ids:nbf a owl:DatatypeProperty;
     rdfs:label "nbf"@en;
     rdfs:domain ids:Token;
-    rdfs:range xsd:int ;
+    rdfs:range xsd:string ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.5> ;
     rdfs:comment "The 'aud' (audience) claim identifies the recipients that the JWT is intended for."@en.
 
 ids:exp a owl:DatatypeProperty;
     rdfs:label "exp"@en;
     rdfs:domain ids:Token;
-    rdfs:range xsd:int ;
+    rdfs:range xsd:string ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.4> ;
     rdfs:comment "The 'exp' (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing."@en.
 

--- a/model/shared/Described.ttl
+++ b/model/shared/Described.ttl
@@ -24,6 +24,7 @@ ids:Concept
 
 ids:Described
     a owl:Class ;
+    idsm:abstract true;
     rdfs:label "described"@en ;
     rdfs:comment "Entity described by a minimal textual annotation, i.e. a title and description."@en;
     idsm:validation [
@@ -43,25 +44,16 @@ ids:title #.. how does it relate to "name", is "title" a functional property?
     a owl:DatatypeProperty ;
     rdfs:subPropertyOf dct:title ;
     rdfs:label "title"@en ;
-    #idsm:labelPluralForm "titles"@en;
     rdfs:domain ids:Described ;
     rdfs:range rdf:PlainLiteral;
     rdfs:comment "(Localized) name of the entity."@en .
 
 #TODO: change range to skos:Concept
 ids:description
-    a owl:ObjectProperty ;
+    a owl:DatatypeProperty ;
     rdfs:subPropertyOf dct:description ;
     rdfs:label "description"@en ;
-    #idsm:labelPluralForm "descriptions"@en;
     rdfs:domain ids:Described ;
-    rdfs:range ids:Concept ; #allows using skos:broader
-    rdfs:comment "Reference to another resource which may describe this resource further"@en .
-
-#TODO: This is only a helper property and should be removed in the future
-ids:comment
-	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf rdfs:comment ;
-	rdfs:label "comment"@en ;
-	rdfs:range rdf:PlainLiteral ;
-	rdfs:comment "(Localized) textual description of the entity."@en .
+    rdfs:range rdf:PlainLiteral ; #allows using skos:broader
+    rdfs:comment "Explanation of the resource in a natural language text."@en ;
+    .

--- a/model/traceability/Activity.ttl
+++ b/model/traceability/Activity.ttl
@@ -82,7 +82,6 @@ ids:activityDescription rdfs:subPropertyOf dct:description;
     rdfs:domain ids:Activity;
     rdfs:range rdf:PlainLiteral;
     rdfs:label "activityDescription"@en;
-    idsm:labelPluralForm "activityDescriptions"@en;
     rdfs:comment "Freetext description of what has been performed by the Activity."@en.
 
 ids:startedBy rdfs:subPropertyOf prov:wasStartedBy;

--- a/model/traceability/ManagedEntity.ttl
+++ b/model/traceability/ManagedEntity.ttl
@@ -26,7 +26,6 @@ ids:ManagedEntity
 
 ids:lifecycleActivity a owl:ObjectProperty;
     rdfs:label "lifecycleActivity"@en;
-    idsm:labelPluralForm "lifecycleActivities"@en;
     rdfs:domain ids:ManagedEntity;
     rdfs:range ids:Activity;
     rdfs:comment "Activity that occurs during the lifecycle of the Managed Entity."@en.

--- a/testing/communication/ApiDocumentTypeShape.ttl
+++ b/testing/communication/ApiDocumentTypeShape.ttl
@@ -25,7 +25,7 @@ shapes:ApiDocumentTypeShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ApiDocumentTypeShape.ttl> (ApiDocumentTypeShape): An ids:ApiDocumentType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ApiDocumentTypeShape.ttl> (ApiDocumentTypeShape): An ids:ApiDocumentType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/communication/EndpointShape.ttl
+++ b/testing/communication/EndpointShape.ttl
@@ -27,7 +27,7 @@ shapes:EndpointShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:Endpoint is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:Endpoint is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:EndpointShape
 		sh:path ids:endpointHost ;
 		sh:class ids:Host ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:endpointHost property must point from an ids:Endpoint to an ids:Host."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:endpointHost property must point from an ids:Endpoint to an ids:Host."@en ; 
 	] ;
 
 	sh:property [
@@ -51,7 +51,7 @@ shapes:EndpointShape
 		sh:path ids:path ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:path property must point from an ids:Endpoint to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:path property must point from an ids:Endpoint to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -59,7 +59,7 @@ shapes:EndpointShape
 		sh:path ids:inboundPath ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:inboundPath property must point from an ids:Endpoint to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:inboundPath property must point from an ids:Endpoint to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -67,7 +67,7 @@ shapes:EndpointShape
 		sh:path ids:outboundPath ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:outboundPath property must point from an ids:Endpoint to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (EndpointShape): An ids:outboundPath property must point from an ids:Endpoint to an xsd:string."@en ; 
 	] .
 
 
@@ -80,7 +80,7 @@ shapes:StaticEndpointShape
 		sh:path ids:endpointArtifact ;
 		sh:class ids:Artifact ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (StaticEndpointShape): An ids:endpointArtifact property must point from an ids:StaticEndpoint to an ids:Artifact."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (StaticEndpointShape): An ids:endpointArtifact property must point from an ids:StaticEndpoint to an ids:Artifact."@en ; 
 	] .
 
 
@@ -93,6 +93,6 @@ shapes:InteractiveEndpointShape
 		sh:path ids:endpointOperationBinding ;
 		sh:class ids:OperationBinding ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/EndpointShape.ttl> (InteractiveEndpointShape): An ids:endpointOperationBinding property must point from an ids:InteractiveEndpoint to an ids:OperationBinding."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/EndpointShape.ttl> (InteractiveEndpointShape): An ids:endpointOperationBinding property must point from an ids:InteractiveEndpoint to an ids:OperationBinding."@en ; 
 	] .
 

--- a/testing/communication/HostShape.ttl
+++ b/testing/communication/HostShape.ttl
@@ -30,7 +30,7 @@ shapes:HostShape
 		sh:path ids:protocol ;
 		sh:class ids:Protocol ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/HostShape.ttl> (HostShape): An ids:protocol property must point from an ids:Host to an ids:Protocol."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:protocol property must point from an ids:Host to an ids:Protocol."@en ; 
 	] ;
 
 	sh:property [
@@ -38,7 +38,7 @@ shapes:HostShape
 		sh:path ids:accessUrl ;
 		sh:datatype xsd:anyURI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/HostShape.ttl> (HostShape): An ids:accessUrl property must point from an ids:Host to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:accessUrl property must point from an ids:Host to an xsd:anyURI."@en ; 
 	] ;
 
 	sh:property [
@@ -46,6 +46,6 @@ shapes:HostShape
 		sh:path ids:pathPrefix ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/HostShape.ttl> (HostShape): An ids:pathPrefix property must point from an ids:Host to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:pathPrefix property must point from an ids:Host to an xsd:string."@en ; 
 	] .
 

--- a/testing/communication/InterfaceShape.ttl
+++ b/testing/communication/InterfaceShape.ttl
@@ -30,6 +30,6 @@ shapes:InterfaceShape
 		sh:path ids:operation ;
 		sh:class ids:Operation ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/InterfaceShape.ttl> (InterfaceShape): An ids:operation property must point from an ids:Interface to an ids:Operation."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/InterfaceShape.ttl> (InterfaceShape): An ids:operation property must point from an ids:Interface to an ids:Operation."@en ; 
 	] .
 

--- a/testing/communication/MessageExchangePatternShape.ttl
+++ b/testing/communication/MessageExchangePatternShape.ttl
@@ -30,6 +30,6 @@ shapes:MessageExchangePatternShape
 		sh:path ids:faultPropagationRule ;
 		sh:class ids:FaultPropagationRule ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageExchangePatternShape.ttl> (MessageExchangePatternShape): An ids:faultPropagationRule property must point from an ids:MessageExchangePattern to an ids:FaultPropagationRule."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageExchangePatternShape.ttl> (MessageExchangePatternShape): An ids:faultPropagationRule property must point from an ids:MessageExchangePattern to an ids:FaultPropagationRule."@en ; 
 	] .
 

--- a/testing/communication/MessageShape.ttl
+++ b/testing/communication/MessageShape.ttl
@@ -32,7 +32,7 @@ shapes:MessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one xsd:string linked through the ids:modelVersion property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one xsd:string linked through the ids:modelVersion property"@en ; 
 	] ;
 
 	sh:property [
@@ -42,7 +42,7 @@ shapes:MessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one xsd:dateTime linked through the ids:issued property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one xsd:dateTime linked through the ids:issued property"@en ; 
 	] ;
 
 	sh:property [
@@ -50,7 +50,7 @@ shapes:MessageShape
 		sh:path ids:correlationMessage ;
 		sh:class ids:Message ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:correlationMessage property must point from an ids:Message to an ids:Message."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:correlationMessage property must point from an ids:Message to an ids:Message."@en ; 
 	] ;
 
 	sh:property [
@@ -60,7 +60,7 @@ shapes:MessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one ids:Connector linked through the ids:issuerConnector property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one ids:Connector linked through the ids:issuerConnector property"@en ; 
 	] ;
 
 	sh:property [
@@ -68,7 +68,7 @@ shapes:MessageShape
 		sh:path ids:recipientConnector ;
 		sh:class ids:Connector ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector."@en ; 
 	] ;
 
 	sh:property [
@@ -77,7 +77,7 @@ shapes:MessageShape
 		sh:datatype ids:Agent ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have at least one ids:Agent linked through the ids:senderAgent property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have at least one ids:Agent linked through the ids:senderAgent property"@en ; 
 	] ;
 
 	sh:property [
@@ -85,7 +85,7 @@ shapes:MessageShape
 		sh:path ids:recipientAgent ;
 		sh:datatype ids:Agent ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientAgent property must point from an ids:Message to an ids:Agent."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientAgent property must point from an ids:Message to an ids:Agent."@en ; 
 	] ;
 
 	sh:property [
@@ -95,7 +95,7 @@ shapes:MessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one security token, which points to an ids:DynamicAttributeToken."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have exactly one security token, which points to an ids:DynamicAttributeToken."@en ; 
 	] ;
 
 	sh:property [
@@ -103,7 +103,7 @@ shapes:MessageShape
 		sh:path ids:authorizationToken ;
 		sh:class ids:Token ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:authorizationToken property must point from an ids:Message to an ids:Token."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:authorizationToken property must point from an ids:Message to an ids:Token."@en ; 
 	] ;
 
 	sh:property [
@@ -111,7 +111,7 @@ shapes:MessageShape
 		sh:path ids:transferContract ;
 		sh:class ids:Contract ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:transferContract property must point from an ids:Message to an ids:Contract."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:transferContract property must point from an ids:Message to an ids:Contract."@en ; 
 	] ;
 
 	sh:property [
@@ -119,6 +119,6 @@ shapes:MessageShape
 		sh:path ids:contentVersion ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/MessageShape.ttl> (MessageShape): An ids:contentVersion property must point from an ids:Message to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:contentVersion property must point from an ids:Message to an xsd:string."@en ; 
 	] .
 

--- a/testing/communication/OperationBindingShape.ttl
+++ b/testing/communication/OperationBindingShape.ttl
@@ -30,7 +30,7 @@ shapes:OperationBindingShape
 		sh:path ids:apiDocument ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationBindingShape.ttl> (OperationBindingShape): An ids:apiDocument property must point from an ids:OperationBinding to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationBindingShape.ttl> (OperationBindingShape): An ids:apiDocument property must point from an ids:OperationBinding to an ids:Resource."@en ; 
 	] ;
 
 	sh:property [
@@ -38,6 +38,6 @@ shapes:OperationBindingShape
 		sh:path ids:boundOperation ;
 		sh:class ids:Operation ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationBindingShape.ttl> (OperationBindingShape): An ids:boundOperation property must point from an ids:OperationBinding to an ids:Operation."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationBindingShape.ttl> (OperationBindingShape): An ids:boundOperation property must point from an ids:OperationBinding to an ids:Operation."@en ; 
 	] .
 

--- a/testing/communication/OperationShape.ttl
+++ b/testing/communication/OperationShape.ttl
@@ -27,7 +27,7 @@ shapes:OperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/OperationShape.ttl> (OperationShape): An ids:Operation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/OperationShape.ttl> (OperationShape): An ids:Operation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:OperationShape
 		sh:path ids:operationType ;
 		sh:class ids:OperationType ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:operationType property must point from an ids:Operation to an ids:OperationType."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:operationType property must point from an ids:Operation to an ids:OperationType."@en ; 
 	] ;
 
 	sh:property [
@@ -51,7 +51,7 @@ shapes:OperationShape
 		sh:path ids:pattern ;
 		sh:class ids:MessageExchangePattern ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:pattern property must point from an ids:Operation to an ids:MessageExchangePattern."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:pattern property must point from an ids:Operation to an ids:MessageExchangePattern."@en ; 
 	] ;
 
 	sh:property [
@@ -59,7 +59,7 @@ shapes:OperationShape
 		sh:path ids:input ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:input property must point from an ids:Operation to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:input property must point from an ids:Operation to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -67,7 +67,7 @@ shapes:OperationShape
 		sh:path ids:mandatoryInput ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryInput property must point from an ids:Operation to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryInput property must point from an ids:Operation to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -75,7 +75,7 @@ shapes:OperationShape
 		sh:path ids:inputGroup ;
 		sh:class ids:ParameterGroup ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:inputGroup property must point from an ids:Operation to an ids:ParameterGroup."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:inputGroup property must point from an ids:Operation to an ids:ParameterGroup."@en ; 
 	] ;
 
 	sh:property [
@@ -83,7 +83,7 @@ shapes:OperationShape
 		sh:path ids:mandatoryInputGroup ;
 		sh:class ids:ParameterGroup ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryInputGroup property must point from an ids:Operation to an ids:ParameterGroup."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryInputGroup property must point from an ids:Operation to an ids:ParameterGroup."@en ; 
 	] ;
 
 	sh:property [
@@ -91,7 +91,7 @@ shapes:OperationShape
 		sh:path ids:output ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:output property must point from an ids:Operation to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:output property must point from an ids:Operation to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -99,7 +99,7 @@ shapes:OperationShape
 		sh:path ids:mandatoryOutput ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryOutput property must point from an ids:Operation to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:mandatoryOutput property must point from an ids:Operation to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -107,6 +107,6 @@ shapes:OperationShape
 		sh:path ids:fault ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/OperationShape.ttl> (OperationShape): An ids:fault property must point from an ids:Operation to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/OperationShape.ttl> (OperationShape): An ids:fault property must point from an ids:Operation to an ids:Parameter."@en ; 
 	] .
 

--- a/testing/communication/ParameterAssignmentShape.ttl
+++ b/testing/communication/ParameterAssignmentShape.ttl
@@ -30,7 +30,7 @@ shapes:ParameterAssignmentShape
 		sh:path ids:parameter ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameter property must point from an ids:ParameterAssignment to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameter property must point from an ids:ParameterAssignment to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -38,7 +38,7 @@ shapes:ParameterAssignmentShape
 		sh:path ids:parameterValue ;
 		sh:class ids:Value ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameterValue property must point from an ids:ParameterAssignment to an ids:Value."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameterValue property must point from an ids:ParameterAssignment to an ids:Value."@en ; 
 	] ;
 
 	sh:property [
@@ -46,6 +46,6 @@ shapes:ParameterAssignmentShape
 		sh:path ids:parameterArtifact ;
 		sh:class ids:Artifact ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameterArtifact property must point from an ids:ParameterAssignment to an ids:Artifact."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterAssignmentShape.ttl> (ParameterAssignmentShape): An ids:parameterArtifact property must point from an ids:ParameterAssignment to an ids:Artifact."@en ; 
 	] .
 

--- a/testing/communication/ParameterGroupShape.ttl
+++ b/testing/communication/ParameterGroupShape.ttl
@@ -30,7 +30,7 @@ shapes:ParameterGroupShape
 		sh:path ids:paramGroupMember ;
 		sh:class ids:Parameter ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterGroupShape.ttl> (ParameterGroupShape): An ids:paramGroupMember property must point from an ids:ParameterGroup to an ids:Parameter."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterGroupShape.ttl> (ParameterGroupShape): An ids:paramGroupMember property must point from an ids:ParameterGroup to an ids:Parameter."@en ; 
 	] ;
 
 	sh:property [
@@ -38,6 +38,6 @@ shapes:ParameterGroupShape
 		sh:path ids:paramGroupingOperator ;
 		sh:class ids:ParameterGroupingOperator ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterGroupShape.ttl> (ParameterGroupShape): An ids:paramGroupingOperator property must point from an ids:ParameterGroup to an ids:ParameterGroupingOperator."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterGroupShape.ttl> (ParameterGroupShape): An ids:paramGroupingOperator property must point from an ids:ParameterGroup to an ids:ParameterGroupingOperator."@en ; 
 	] .
 

--- a/testing/communication/ParameterGroupingOperatorShape.ttl
+++ b/testing/communication/ParameterGroupingOperatorShape.ttl
@@ -26,7 +26,7 @@ shapes:ParameterGroupingOperatorShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterGroupingOperatorShape.ttl> (ParameterGroupingOperatorShape): An ids:ParameterGroupingOperator is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterGroupingOperatorShape.ttl> (ParameterGroupingOperatorShape): An ids:ParameterGroupingOperator is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/communication/ParameterShape.ttl
+++ b/testing/communication/ParameterShape.ttl
@@ -30,6 +30,6 @@ shapes:ParameterShape
 		sh:path ids:parameterContent ;
 		sh:class ids:DigitalContent ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/communication/ParameterShape.ttl> (ParameterShape): An ids:parameterContent property must point from an ids:Parameter to an ids:DigitalContent."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/ParameterShape.ttl> (ParameterShape): An ids:parameterContent property must point from an ids:Parameter to an ids:DigitalContent."@en ; 
 	] .
 

--- a/testing/content/ArtifactShape.ttl
+++ b/testing/content/ArtifactShape.ttl
@@ -32,7 +32,7 @@ shapes:ArtifactShape
 		sh:datatype xsd:nonNegativeInteger ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:nonNegativeInteger linked through the ids:byteSize property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:nonNegativeInteger linked through the ids:byteSize property"@en ; 
 	] ;
 
 	sh:property [
@@ -41,7 +41,7 @@ shapes:ArtifactShape
 		sh:datatype xsd:string ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:string linked through the ids:fileName property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:string linked through the ids:fileName property"@en ; 
 	] ;
 
 	sh:property [
@@ -50,7 +50,7 @@ shapes:ArtifactShape
 		sh:datatype xsd:date ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:date linked through the ids:creationDate property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:date linked through the ids:creationDate property"@en ; 
 	] ;
 
 	sh:property [
@@ -58,7 +58,7 @@ shapes:ArtifactShape
 		sh:path ids:artifactParameterization ;
 		sh:class ids:ParameterAssignment ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:artifactParameterization property must point from an ids:Artifact to an ids:ParameterAssignment."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:artifactParameterization property must point from an ids:Artifact to an ids:ParameterAssignment."@en ; 
 	] ;
 
 	sh:property [
@@ -67,7 +67,7 @@ shapes:ArtifactShape
 		sh:datatype xsd:string ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:string linked through the ids:checkSum property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:string linked through the ids:checkSum property"@en ; 
 	] ;
 
 	sh:property [
@@ -75,6 +75,6 @@ shapes:ArtifactShape
 		sh:path ids:duration ;
 		sh:datatype xsd:decimal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:duration property must point from an ids:Artifact to an xsd:decimal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:duration property must point from an ids:Artifact to an xsd:decimal."@en ; 
 	] .
 

--- a/testing/content/ConceptShape.ttl
+++ b/testing/content/ConceptShape.ttl
@@ -28,7 +28,7 @@ shapes:ConceptShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ConceptShape.ttl> (ConceptShape): An ids:Concept is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ConceptShape.ttl> (ConceptShape): An ids:Concept is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/content/DataAppShape.ttl
+++ b/testing/content/DataAppShape.ttl
@@ -25,7 +25,7 @@ shapes:DataAppShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DataAppShape.ttl> (DataAppShape): An ids:DataApp is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DataAppShape.ttl> (DataAppShape): An ids:DataApp is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/content/DigitalContentShape.ttl
+++ b/testing/content/DigitalContentShape.ttl
@@ -27,7 +27,7 @@ shapes:DigitalContentShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:DigitalContent is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:DigitalContent is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:DigitalContentShape
 		sh:path ids:contentType ;
 		sh:class ids:ContentType ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentType property must point from an ids:DigitalContent to an ids:ContentType."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentType property must point from an ids:DigitalContent to an ids:ContentType."@en ; 
 	] ;
 
 	sh:property [
@@ -51,7 +51,7 @@ shapes:DigitalContentShape
 		sh:path ids:contentPart ;
 		sh:class ids:DigitalContent ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentPart property must point from an ids:DigitalContent to an ids:DigitalContent."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentPart property must point from an ids:DigitalContent to an ids:DigitalContent."@en ; 
 	] ;
 
 	sh:property [
@@ -59,7 +59,7 @@ shapes:DigitalContentShape
 		sh:path ids:representation ;
 		sh:class ids:Representation ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:representation property must point from an ids:DigitalContent to an ids:Representation."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:representation property must point from an ids:DigitalContent to an ids:Representation."@en ; 
 	] ;
 
 	sh:property [
@@ -67,7 +67,7 @@ shapes:DigitalContentShape
 		sh:path ids:defaultRepresentation ;
 		sh:class ids:Representation ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:defaultRepresentation property must point from an ids:DigitalContent to an ids:Representation."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:defaultRepresentation property must point from an ids:DigitalContent to an ids:Representation."@en ; 
 	] ;
 
 	sh:property [
@@ -75,7 +75,7 @@ shapes:DigitalContentShape
 		sh:path ids:language ;
 		sh:class ids:Language ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:language property must point from an ids:DigitalContent to an ids:Language."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:language property must point from an ids:DigitalContent to an ids:Language."@en ; 
 	] ;
 
 	sh:property [
@@ -83,7 +83,7 @@ shapes:DigitalContentShape
 		sh:path ids:theme ;
 		sh:class ids:Concept ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:theme property must point from an ids:DigitalContent to an ids:Concept."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:theme property must point from an ids:DigitalContent to an ids:Concept."@en ; 
 	] ;
 
 	sh:property [
@@ -91,7 +91,7 @@ shapes:DigitalContentShape
 		sh:path ids:keyword ;
 		sh:datatype rdfs:Literal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:keyword property must point from an ids:DigitalContent to an rdfs:Literal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:keyword property must point from an ids:DigitalContent to an rdfs:Literal."@en ; 
 	] ;
 
 	sh:property [
@@ -99,7 +99,7 @@ shapes:DigitalContentShape
 		sh:path ids:temporalCoverage ;
 		sh:class ids:TemporalEntity ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:temporalCoverage property must point from an ids:DigitalContent to an ids:TemporalEntity."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:temporalCoverage property must point from an ids:DigitalContent to an ids:TemporalEntity."@en ; 
 	] ;
 
 	sh:property [
@@ -107,7 +107,7 @@ shapes:DigitalContentShape
 		sh:path ids:spatialCoverage ;
 		sh:class ids:SpatialEntity ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:spatialCoverage property must point from an ids:DigitalContent to an ids:SpatialEntity."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:spatialCoverage property must point from an ids:DigitalContent to an ids:SpatialEntity."@en ; 
 	] ;
 
 	sh:property [
@@ -115,7 +115,7 @@ shapes:DigitalContentShape
 		sh:path ids:accrualPeriodicity ;
 		sh:datatype xsd:duration ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:accrualPeriodicity property must point from an ids:DigitalContent to an xsd:duration."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:accrualPeriodicity property must point from an ids:DigitalContent to an xsd:duration."@en ; 
 	] ;
 
 	sh:property [
@@ -123,6 +123,6 @@ shapes:DigitalContentShape
 		sh:path ids:contentStandard ;
 		sh:class ids:Standard ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentStandard property must point from an ids:DigitalContent to an ids:Standard."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:contentStandard property must point from an ids:DigitalContent to an ids:Standard."@en ; 
 	] .
 

--- a/testing/content/LanguageShape.ttl
+++ b/testing/content/LanguageShape.ttl
@@ -25,7 +25,7 @@ shapes:LanguageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/LanguageShape.ttl> (LanguageShape): An ids:Language is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/LanguageShape.ttl> (LanguageShape): An ids:Language is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/content/MediaTypeShape.ttl
+++ b/testing/content/MediaTypeShape.ttl
@@ -26,7 +26,7 @@ shapes:MediaTypeShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/MediaTypeShape.ttl> (MediaTypeShape): An ids:MediaType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/MediaTypeShape.ttl> (MediaTypeShape): An ids:MediaType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -42,6 +42,6 @@ shapes:MediaTypeShape
 		sh:path ids:filenameExtension ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/MediaTypeShape.ttl> (MediaTypeShape): An ids:filenameExtension property must point from an ids:MediaType to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/MediaTypeShape.ttl> (MediaTypeShape): An ids:filenameExtension property must point from an ids:MediaType to an xsd:string."@en ; 
 	] .
 

--- a/testing/content/RepresentationShape.ttl
+++ b/testing/content/RepresentationShape.ttl
@@ -31,7 +31,7 @@ shapes:RepresentationShape
 		sh:path ids:instance ;
 		sh:class ids:RepresentationInstance ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:instance property must point from an ids:Representation to an ids:RepresentationInstance."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:instance property must point from an ids:Representation to an ids:RepresentationInstance."@en ; 
 	] ;
 
 	sh:property [
@@ -40,7 +40,7 @@ shapes:RepresentationShape
 		sh:class ids:MediaType ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:Representation must not have more than one ids:MediaType linked through the ids:mediaType property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:Representation must not have more than one ids:MediaType linked through the ids:mediaType property"@en ; 
 	] ;
 
 	sh:property [
@@ -48,7 +48,7 @@ shapes:RepresentationShape
 		sh:path ids:representationStandard ;
 		sh:class ids:Standard ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:representationStandard property must point from an ids:Representation to an ids:Standard."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:representationStandard property must point from an ids:Representation to an ids:Standard."@en ; 
 	] .
 
 
@@ -58,7 +58,7 @@ shapes:RepresentationInstanceShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/RepresentationShape.ttl> (RepresentationInstanceShape): An ids:RepresentationInstance is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationInstanceShape): An ids:RepresentationInstance is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/content/ResourceShape.ttl
+++ b/testing/content/ResourceShape.ttl
@@ -31,7 +31,7 @@ shapes:ResourceShape
 		sh:path ids:resourcePart ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourcePart property must point from an ids:Resource to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourcePart property must point from an ids:Resource to an ids:Resource."@en ; 
 	] ;
 
 	sh:property [
@@ -39,7 +39,7 @@ shapes:ResourceShape
 		sh:path ids:resourceInterface ;
 		sh:class ids:Interface ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourceInterface property must point from an ids:Resource to an ids:Interface."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourceInterface property must point from an ids:Resource to an ids:Interface."@en ; 
 	] ;
 
 	sh:property [
@@ -47,7 +47,7 @@ shapes:ResourceShape
 		sh:path ids:resourceEndpoint ;
 		sh:class ids:Endpoint ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourceEndpoint property must point from an ids:Resource to an ids:Endpoint."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:resourceEndpoint property must point from an ids:Resource to an ids:Endpoint."@en ; 
 	] ;
 
 	sh:property [
@@ -55,7 +55,7 @@ shapes:ResourceShape
 		sh:path ids:standardLicense ;
 		sh:class ids:License ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:standardLicense property must point from an ids:Resource to an ids:License."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:standardLicense property must point from an ids:Resource to an ids:License."@en ; 
 	] ;
 
 	sh:property [
@@ -63,7 +63,7 @@ shapes:ResourceShape
 		sh:path ids:customLicense ;
 		sh:datatype xsd:anyURI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:customLicense property must point from an ids:Resource to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:customLicense property must point from an ids:Resource to an xsd:anyURI."@en ; 
 	] ;
 
 	sh:property [
@@ -72,7 +72,7 @@ shapes:ResourceShape
 		sh:class ids:ContractOffer ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:Resource must have at least one ids:ContractOffer linked through the ids:contractOffer property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:Resource must have at least one ids:ContractOffer linked through the ids:contractOffer property"@en ; 
 	] ;
 
 	sh:property [
@@ -80,7 +80,7 @@ shapes:ResourceShape
 		sh:path ids:publisher ;
 		sh:class ids:Agent ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:publisher property must point from an ids:Resource to an ids:Agent."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:publisher property must point from an ids:Resource to an ids:Agent."@en ; 
 	] ;
 
 	sh:property [
@@ -88,7 +88,7 @@ shapes:ResourceShape
 		sh:path ids:sovereign ;
 		sh:class ids:Agent ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:sovereign property must point from an ids:Resource to an ids:Agent."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:sovereign property must point from an ids:Resource to an ids:Agent."@en ; 
 	] ;
 
 	sh:property [
@@ -96,7 +96,7 @@ shapes:ResourceShape
 		sh:path ids:sample ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:sample property must point from an ids:Resource to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:sample property must point from an ids:Resource to an ids:Resource."@en ; 
 	] ;
 
 	sh:property [
@@ -104,6 +104,6 @@ shapes:ResourceShape
 		sh:path ids:variant ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/content/ResourceShape.ttl> (ResourceShape): An ids:variant property must point from an ids:Resource to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:variant property must point from an ids:Resource to an ids:Resource."@en ; 
 	] .
 

--- a/testing/context/SpatialEntityShape.ttl
+++ b/testing/context/SpatialEntityShape.ttl
@@ -29,7 +29,7 @@ shapes:SpatialEntityShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (SpatialEntityShape): An ids:SpatialEntity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (SpatialEntityShape): An ids:SpatialEntity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -47,7 +47,7 @@ shapes:LocationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (LocationShape): An ids:Location is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (LocationShape): An ids:Location is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -68,7 +68,7 @@ shapes:GeoPointShape
 		sh:path ids:latitude ;
 		sh:datatype xsd:float ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (GeoPointShape): An ids:latitude property must point from an ids:GeoPoint to an xsd:float."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (GeoPointShape): An ids:latitude property must point from an ids:GeoPoint to an xsd:float."@en ; 
 	] ;
 
 	sh:property [
@@ -76,7 +76,7 @@ shapes:GeoPointShape
 		sh:path ids:longitude ;
 		sh:datatype xsd:float ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (GeoPointShape): An ids:longitude property must point from an ids:GeoPoint to an xsd:float."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (GeoPointShape): An ids:longitude property must point from an ids:GeoPoint to an xsd:float."@en ; 
 	] .
 
 
@@ -86,7 +86,7 @@ shapes:GeometryShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (GeometryShape): An ids:Geometry is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (GeometryShape): An ids:Geometry is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -107,6 +107,6 @@ shapes:BoundingPolygonShape
 		sh:path ids:geoPoint ;
 		sh:class ids:GeoPoint ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/SpatialEntityShape.ttl> (BoundingPolygonShape): An ids:geoPoint property must point from an ids:BoundingPolygon to an ids:GeoPoint."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/SpatialEntityShape.ttl> (BoundingPolygonShape): An ids:geoPoint property must point from an ids:BoundingPolygon to an ids:GeoPoint."@en ; 
 	] .
 

--- a/testing/context/TemporalEntityShape.ttl
+++ b/testing/context/TemporalEntityShape.ttl
@@ -30,7 +30,7 @@ shapes:InstantShape
 		sh:path ids:date ;
 		sh:datatype xsd:date ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/TemporalEntityShape.ttl> (InstantShape): An ids:date property must point from an ids:Instant to an xsd:date."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/TemporalEntityShape.ttl> (InstantShape): An ids:date property must point from an ids:Instant to an xsd:date."@en ; 
 	] ;
 
 	sh:property [
@@ -38,7 +38,7 @@ shapes:InstantShape
 		sh:path ids:dateTime ;
 		sh:datatype xsd:dateTime ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/TemporalEntityShape.ttl> (InstantShape): An ids:dateTime property must point from an ids:Instant to an xsd:dateTime."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/TemporalEntityShape.ttl> (InstantShape): An ids:dateTime property must point from an ids:Instant to an xsd:dateTime."@en ; 
 	] .
 
 
@@ -51,7 +51,7 @@ shapes:IntervalShape
 		sh:path ids:begin ;
 		sh:class ids:Instant ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/TemporalEntityShape.ttl> (IntervalShape): An ids:begin property must point from an ids:Interval to an ids:Instant."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/TemporalEntityShape.ttl> (IntervalShape): An ids:begin property must point from an ids:Interval to an ids:Instant."@en ; 
 	] ;
 
 	sh:property [
@@ -59,6 +59,6 @@ shapes:IntervalShape
 		sh:path ids:end ;
 		sh:class ids:Instant ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/context/TemporalEntityShape.ttl> (IntervalShape): An ids:end property must point from an ids:Interval to an ids:Instant."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/context/TemporalEntityShape.ttl> (IntervalShape): An ids:end property must point from an ids:Interval to an ids:Instant."@en ; 
 	] .
 

--- a/testing/contract/ActionShape.ttl
+++ b/testing/contract/ActionShape.ttl
@@ -27,7 +27,7 @@ shapes:ActionShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ActionShape.ttl> (ActionShape): An ids:Action is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ActionShape.ttl> (ActionShape): An ids:Action is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,6 +43,6 @@ shapes:ActionShape
 		sh:path ids:actionRefinement ;
 		sh:class ids:Constraint ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ActionShape.ttl> (ActionShape): An ids:actionRefinement property must point from an ids:Action to an ids:Constraint."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ActionShape.ttl> (ActionShape): An ids:actionRefinement property must point from an ids:Action to an ids:Constraint."@en ; 
 	] .
 

--- a/testing/contract/ContractShape.ttl
+++ b/testing/contract/ContractShape.ttl
@@ -27,7 +27,7 @@ shapes:ContractShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:ContractShape
 		sh:path ids:contractStart ;
 		sh:datatype xsd:dateTime ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractStart property must point from an ids:Contract to an xsd:sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/contract/."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractStart property must point from an ids:Contract to an xsd:sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/contract/."@en ; 
 	] ;
 
 	sh:property [
@@ -51,7 +51,7 @@ shapes:ContractShape
 		sh:path ids:contractEnd ;
 		sh:datatype xsd:dateTime ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractEnd property must point from an ids:Contract to an xsd:sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/contract/."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractEnd property must point from an ids:Contract to an xsd:sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/contract/."@en ; 
 	] ;
 
 	sh:property [
@@ -59,7 +59,7 @@ shapes:ContractShape
 		sh:path ids:contractDate ;
 		sh:datatype xsd:date ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractDate property must point from an ids:Contract to an xsd:date."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractDate property must point from an ids:Contract to an xsd:date."@en ; 
 	] ;
 
 	sh:property [
@@ -68,7 +68,7 @@ shapes:ContractShape
 		sh:class ids:Participant ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must not have more than one ids:Participant linked through the ids:provider property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must not have more than one ids:Participant linked through the ids:provider property"@en ; 
 	] ;
 
 	sh:property [
@@ -76,7 +76,7 @@ shapes:ContractShape
 		sh:path ids:consumer ;
 		sh:class ids:Participant ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:consumer property must point from an ids:Contract to an ids:Participant."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:consumer property must point from an ids:Contract to an ids:Participant."@en ; 
 	] ;
 
 	sh:property [
@@ -86,7 +86,7 @@ shapes:ContractShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must have exactly one ids:TextResource linked through the ids:contractDocument property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must have exactly one ids:TextResource linked through the ids:contractDocument property"@en ; 
 	] ;
 
 	sh:property [
@@ -94,7 +94,7 @@ shapes:ContractShape
 		sh:path ids:contractAnnex ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractAnnex property must point from an ids:Contract to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractAnnex property must point from an ids:Contract to an ids:Resource."@en ; 
 	] ;
 
 	sh:property [
@@ -102,7 +102,7 @@ shapes:ContractShape
 		sh:path ids:permission ;
 		sh:class ids:Permission ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:permission property must point from an ids:Contract to an ids:Permission."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:permission property must point from an ids:Contract to an ids:Permission."@en ; 
 	] ;
 
 	sh:property [
@@ -110,7 +110,7 @@ shapes:ContractShape
 		sh:path ids:prohibition ;
 		sh:class ids:Prohibition ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:prohibition property must point from an ids:Contract to an ids:Prohibition."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:prohibition property must point from an ids:Contract to an ids:Prohibition."@en ; 
 	] ;
 
 	sh:property [
@@ -118,7 +118,7 @@ shapes:ContractShape
 		sh:path ids:obligation ;
 		sh:class ids:Duty ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:obligation property must point from an ids:Contract to an ids:Duty."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:obligation property must point from an ids:Contract to an ids:Duty."@en ; 
 	] ;
 
 	sh:property [
@@ -126,7 +126,7 @@ shapes:ContractShape
 		sh:path ids:refersTo ;
 		sh:class ids:PolicyTemplate ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:refersTo property must point from an ids:Contract to an ids:PolicyTemplate."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:refersTo property must point from an ids:Contract to an ids:PolicyTemplate."@en ; 
 	] ;
 
 	sh:property [
@@ -134,7 +134,7 @@ shapes:ContractShape
 		sh:path (ids:permission ids:obligation ids:prohibition) ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must have at least one ids:permission, ids:obligation or ids:prohibition property linked."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must have at least one ids:permission, ids:obligation or ids:prohibition property linked."@en ; 
 	] .
 
 
@@ -149,7 +149,7 @@ shapes:ContractAgreementShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractAgreementShape): An ids:Contract must have exactly one ids:Participant linked through the ids:consumer property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractAgreementShape): An ids:Contract must have exactly one ids:Participant linked through the ids:consumer property"@en ; 
 	] ;
 
 	sh:property [
@@ -159,7 +159,7 @@ shapes:ContractAgreementShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractAgreementShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractAgreementShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
 	] .
 
 
@@ -174,7 +174,7 @@ shapes:ContractRequestShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractRequestShape): An ids:Contract must have exactly one ids:Participant linked through the ids:consumer property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractRequestShape): An ids:Contract must have exactly one ids:Participant linked through the ids:consumer property"@en ; 
 	] ;
 
 	sh:property [
@@ -184,7 +184,7 @@ shapes:ContractRequestShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractRequestShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractRequestShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
 	] .
 
 
@@ -199,6 +199,6 @@ shapes:ContractOfferShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/ContractShape.ttl> (ContractOfferShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractOfferShape): An ids:Contract must have exactly one ids:Participant linked through the ids:provider property"@en ; 
 	] .
 

--- a/testing/contract/PaymentShape.ttl
+++ b/testing/contract/PaymentShape.ttl
@@ -27,7 +27,7 @@ shapes:PaymentModelShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PaymentShape.ttl> (PaymentModelShape): An ids:PaymentModel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PaymentShape.ttl> (PaymentModelShape): An ids:PaymentModel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:ImmediatePaymentShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PaymentShape.ttl> (ImmediatePaymentShape): An ids:ImmediatePayment is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PaymentShape.ttl> (ImmediatePaymentShape): An ids:ImmediatePayment is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/contract/PolicyShape.ttl_toGlossary
+++ b/testing/contract/PolicyShape.ttl_toGlossary
@@ -27,7 +27,7 @@ shapes:UsagePolicyShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PolicyShape.ttl_toGlossary> (UsagePolicyShape): An ids:UsagePolicy is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PolicyShape.ttl_toGlossary> (UsagePolicyShape): An ids:UsagePolicy is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/contract/PricingModelShape.ttl
+++ b/testing/contract/PricingModelShape.ttl
@@ -27,7 +27,7 @@ shapes:PricingModelShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PricingModelShape.ttl> (PricingModelShape): An ids:PricingModel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PricingModelShape.ttl> (PricingModelShape): An ids:PricingModel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:PricingModelShape
 		sh:path ids:pricingOption ;
 		sh:class ids:PricingOption ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PricingModelShape.ttl> (PricingModelShape): An ids:pricingOption property must point from an ids:PricingModel to an ids:PricingOption."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PricingModelShape.ttl> (PricingModelShape): An ids:pricingOption property must point from an ids:PricingModel to an ids:PricingOption."@en ; 
 	] .
 
 
@@ -53,7 +53,7 @@ shapes:PricingOptionShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PricingModelShape.ttl> (PricingOptionShape): An ids:PricingOption is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PricingModelShape.ttl> (PricingOptionShape): An ids:PricingOption is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -71,7 +71,7 @@ shapes:ChargeableUseShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PricingModelShape.ttl> (ChargeableUseShape): An ids:ChargeableUse is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PricingModelShape.ttl> (ChargeableUseShape): An ids:ChargeableUse is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -89,7 +89,7 @@ shapes:ConsumptionBasedPricingShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/PricingModelShape.ttl> (ConsumptionBasedPricingShape): An ids:ConsumptionBasedPricing is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/PricingModelShape.ttl> (ConsumptionBasedPricingShape): An ids:ConsumptionBasedPricing is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -28,7 +28,7 @@ shapes:RuleShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:RuleShape
 		sh:class ids:Action ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have at least one ids:Action linked through the ids:action property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have at least one ids:Action linked through the ids:action property"@en ; 
 	] ;
 
 	sh:property [
@@ -55,7 +55,7 @@ shapes:RuleShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:Participant linked through the ids:assignee property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:Participant linked through the ids:assignee property"@en ; 
 	] ;
 
 	sh:property [
@@ -65,7 +65,7 @@ shapes:RuleShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:Participant linked through the ids:assigner property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:Participant linked through the ids:assigner property"@en ; 
 	] ;
 
 	sh:property [
@@ -73,7 +73,7 @@ shapes:RuleShape
 		sh:path ids:targetArtifact ;
 		sh:class ids:Artifact ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:targetArtifact property must point from an ids:Rule to an ids:Artifact."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:targetArtifact property must point from an ids:Rule to an ids:Artifact."@en ; 
 	] ;
 
 	sh:property [
@@ -83,7 +83,7 @@ shapes:RuleShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:DigitalContent linked through the ids:targetContent property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:Rule must have exactly one ids:DigitalContent linked through the ids:targetContent property"@en ; 
 	] ;
 
 	sh:property [
@@ -91,7 +91,7 @@ shapes:RuleShape
 		sh:path ids:constraint ;
 		sh:class ids:Constraint ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (RuleShape): An ids:constraint property must point from an ids:Rule to an ids:Constraint."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An ids:constraint property must point from an ids:Rule to an ids:Constraint."@en ; 
 	] .
 
 
@@ -104,7 +104,7 @@ shapes:PermissionShape
 		sh:path ids:duty ;
 		sh:class ids:Duty ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (PermissionShape): An ids:duty property must point from an ids:Permission to an ids:Duty."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (PermissionShape): An ids:duty property must point from an ids:Permission to an ids:Duty."@en ; 
 	] .
 
 
@@ -118,7 +118,7 @@ shapes:ConstraintShape
 		sh:class ids:LeftOperand ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:LeftOperand linked through the ids:leftOperand property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:LeftOperand linked through the ids:leftOperand property"@en ; 
 	] ;
 
 	sh:property [
@@ -127,7 +127,7 @@ shapes:ConstraintShape
 		sh:class ids:BinaryOperator ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:BinaryOperator linked through the ids:operator property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:BinaryOperator linked through the ids:operator property"@en ; 
 	] ;
 
 	sh:property [
@@ -136,7 +136,7 @@ shapes:ConstraintShape
 		sh:datatype rdfs:Literal ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand property"@en ; 
 	] ;
 
 	sh:property [
@@ -144,6 +144,6 @@ shapes:ConstraintShape
 		sh:path ids:unit ;
 		sh:class ids:Unit ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:unit property must point from an ids:Constraint to an ids:Unit."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:unit property must point from an ids:Constraint to an ids:Unit."@en ; 
 	] .
 

--- a/testing/governance/CertificationShape.ttl
+++ b/testing/governance/CertificationShape.ttl
@@ -27,7 +27,7 @@ shapes:CertificationBodyShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationBodyShape): An ids:CertificationBody is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationBodyShape): An ids:CertificationBody is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:CertificationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:Certification is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:Certification is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -61,7 +61,7 @@ shapes:CertificationShape
 		sh:path ids:certificationLevel ;
 		sh:class ids:CertificationLevel ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:certificationLevel property must point from an ids:Certification to an ids:CertificationLevel."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:certificationLevel property must point from an ids:Certification to an ids:CertificationLevel."@en ; 
 	] ;
 
 	sh:property [
@@ -69,7 +69,7 @@ shapes:CertificationShape
 		sh:path ids:lastValidDate ;
 		sh:datatype xsd:date ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:lastValidDate property must point from an ids:Certification to an xsd:date."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:lastValidDate property must point from an ids:Certification to an xsd:date."@en ; 
 	] ;
 
 	sh:property [
@@ -77,7 +77,7 @@ shapes:CertificationShape
 		sh:path ids:evaluationFacility ;
 		sh:class ids:EvaluationFacility ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:evaluationFacility property must point from an ids:Certification to an ids:EvaluationFacility."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationShape): An ids:evaluationFacility property must point from an ids:Certification to an ids:EvaluationFacility."@en ; 
 	] .
 
 
@@ -87,7 +87,7 @@ shapes:CertificationSchemeShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationSchemeShape): An ids:CertificationScheme is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationSchemeShape): An ids:CertificationScheme is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -105,7 +105,7 @@ shapes:CertificationLevelShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationLevelShape): An ids:CertificationLevel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationLevelShape): An ids:CertificationLevel is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -121,6 +121,6 @@ shapes:CertificationLevelShape
 		sh:path ids:includedCertificationLevel ;
 		sh:class ids:CertificationLevel ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/CertificationShape.ttl> (CertificationLevelShape): An ids:includedCertificationLevel property must point from an ids:CertificationLevel to an ids:CertificationLevel."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/CertificationShape.ttl> (CertificationLevelShape): An ids:includedCertificationLevel property must point from an ids:CertificationLevel to an ids:CertificationLevel."@en ; 
 	] .
 

--- a/testing/governance/DataSovereigntyShape.ttl_toGlossary
+++ b/testing/governance/DataSovereigntyShape.ttl_toGlossary
@@ -27,7 +27,7 @@ shapes:DataSovereigntyShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/DataSovereigntyShape.ttl_toGlossary> (DataSovereigntyShape): An ids:DataSovereignty is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/DataSovereigntyShape.ttl_toGlossary> (DataSovereigntyShape): An ids:DataSovereignty is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/governance/GovernanceShape.ttl_toGlossary
+++ b/testing/governance/GovernanceShape.ttl_toGlossary
@@ -27,7 +27,7 @@ shapes:GovernanceShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/governance/GovernanceShape.ttl_toGlossary> (GovernanceShape): An ids:Governance is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/governance/GovernanceShape.ttl_toGlossary> (GovernanceShape): An ids:Governance is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/infrastructure/BrokerShape.ttl
+++ b/testing/infrastructure/BrokerShape.ttl
@@ -28,6 +28,6 @@ shapes:BrokerShape
 		sh:path ids:connector ;
 		sh:class ids:Connector ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/BrokerShape.ttl> (BrokerShape): An ids:connector property must point from an ids:Broker to an ids:Connector."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (BrokerShape): An ids:connector property must point from an ids:Broker to an ids:Connector."@en ; 
 	] .
 

--- a/testing/infrastructure/CatalogShape.ttl
+++ b/testing/infrastructure/CatalogShape.ttl
@@ -30,7 +30,7 @@ shapes:CatalogShape
 		sh:path ids:offer ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:offer property must point from an ids:Catalog to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:offer property must point from an ids:Catalog to an ids:Resource."@en ; 
 	] ;
 
 	sh:property [
@@ -38,6 +38,6 @@ shapes:CatalogShape
 		sh:path ids:request ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:request property must point from an ids:Catalog to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:request property must point from an ids:Catalog to an ids:Resource."@en ; 
 	] .
 

--- a/testing/infrastructure/ComponentShape.ttl
+++ b/testing/infrastructure/ComponentShape.ttl
@@ -28,7 +28,7 @@ shapes:InfrastructureComponentShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:InfrastructureComponentShape
 		sh:class ids:Participant ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one ids:Participant linked through the ids:maintainer property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one ids:Participant linked through the ids:maintainer property"@en ; 
 	] ;
 
 	sh:property [
@@ -54,7 +54,7 @@ shapes:InfrastructureComponentShape
 		sh:class ids:Participant ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one ids:Participant linked through the ids:curator property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one ids:Participant linked through the ids:curator property"@en ; 
 	] ;
 
 	sh:property [
@@ -62,7 +62,7 @@ shapes:InfrastructureComponentShape
 		sh:path ids:physicalLocation ;
 		sh:class ids:Location ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:physicalLocation property must point from an ids:InfrastructureComponent to an ids:Location."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:physicalLocation property must point from an ids:InfrastructureComponent to an ids:Location."@en ; 
 	] ;
 
 	sh:property [
@@ -70,7 +70,7 @@ shapes:InfrastructureComponentShape
 		sh:path ids:inboundModelVersion ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:inboundModelVersion property must point from an ids:InfrastructureComponent to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:inboundModelVersion property must point from an ids:InfrastructureComponent to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -79,7 +79,7 @@ shapes:InfrastructureComponentShape
 		sh:datatype xsd:string ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one xsd:string linked through the ids:outboundModelVersion property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:InfrastructureComponent must have at least one xsd:string linked through the ids:outboundModelVersion property"@en ; 
 	] ;
 
 	sh:property [
@@ -87,7 +87,7 @@ shapes:InfrastructureComponentShape
 		sh:path ids:componentCertification ;
 		sh:class ids:ComponentCertification ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:componentCertification property must point from an ids:InfrastructureComponent to an ids:ComponentCertification."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:componentCertification property must point from an ids:InfrastructureComponent to an ids:ComponentCertification."@en ; 
 	] ;
 
 	sh:property [
@@ -95,6 +95,6 @@ shapes:InfrastructureComponentShape
 		sh:path ids:publicKey ;
 		sh:class ids:PublicKey ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:publicKey property must point from an ids:InfrastructureComponent to an ids:PublicKey."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ComponentShape.ttl> (InfrastructureComponentShape): An ids:publicKey property must point from an ids:InfrastructureComponent to an ids:PublicKey."@en ; 
 	] .
 

--- a/testing/infrastructure/ConnectorShape.ttl
+++ b/testing/infrastructure/ConnectorShape.ttl
@@ -27,7 +27,7 @@ shapes:ConnectorShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -43,7 +43,7 @@ shapes:ConnectorShape
 		sh:path ids:host ;
 		sh:class ids:Host ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:host property must point from an ids:Connector to an ids:Host."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:host property must point from an ids:Connector to an ids:Host."@en ; 
 	] ;
 
 	sh:property [
@@ -51,7 +51,7 @@ shapes:ConnectorShape
 		sh:path ids:defaultHost ;
 		sh:class ids:Host ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:defaultHost property must point from an ids:Connector to an ids:Host."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:defaultHost property must point from an ids:Connector to an ids:Host."@en ; 
 	] ;
 
 	sh:property [
@@ -61,7 +61,7 @@ shapes:ConnectorShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must have exactly one ids:CustomSecurityProfile linked through the ids:securityProfile property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must have exactly one ids:CustomSecurityProfile linked through the ids:securityProfile property"@en ; 
 	] ;
 	
 	sh:property [
@@ -69,7 +69,7 @@ shapes:ConnectorShape
 		sh:path ids:extendedGuarantee ;
 		sh:class ids:SecurityGuarantee ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): The ids:extendedGuarantee property must point from an ids:Connector to an ids:SecurityGuarantee"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): The ids:extendedGuarantee property must point from an ids:Connector to an ids:SecurityGuarantee"@en ; 
 	] ;
 
 	sh:property [
@@ -77,7 +77,7 @@ shapes:ConnectorShape
 		sh:path ids:authInfo ;
 		sh:class ids:AuthInfo ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:authInfo property must point from an ids:Connector to an ids:AuthInfo."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:authInfo property must point from an ids:Connector to an ids:AuthInfo."@en ; 
 	] ;
 
 	sh:property [
@@ -87,6 +87,6 @@ shapes:ConnectorShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must have exactly one ids:Catalog linked through the ids:catalog property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must have exactly one ids:Catalog linked through the ids:catalog property"@en ; 
 	] .
 

--- a/testing/infrastructure/PublicKeyShape.ttl
+++ b/testing/infrastructure/PublicKeyShape.ttl
@@ -28,7 +28,7 @@ shapes:PublicKeyShape
 		sh:path ids:keyType ;
 		sh:class ids:KeyType ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/PublicKeyShape.ttl> (PublicKeyShape): An ids:keyType property must point from an ids:PublicKey to an ids:KeyType."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/PublicKeyShape.ttl> (PublicKeyShape): An ids:keyType property must point from an ids:PublicKey to an ids:KeyType."@en ; 
 	] ;
 
 	sh:property [
@@ -36,7 +36,7 @@ shapes:PublicKeyShape
 		sh:path ids:keyValue ;
 		sh:datatype xsd:base64Binary ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/PublicKeyShape.ttl> (PublicKeyShape): An ids:keyValue property must point from an ids:PublicKey to an xsd:base64Binary."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/PublicKeyShape.ttl> (PublicKeyShape): An ids:keyValue property must point from an ids:PublicKey to an xsd:base64Binary."@en ; 
 	] .
 
 
@@ -46,7 +46,7 @@ shapes:KeyTypeShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/PublicKeyShape.ttl> (KeyTypeShape): An ids:KeyType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/PublicKeyShape.ttl> (KeyTypeShape): An ids:KeyType is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/infrastructure/VocabularyHubShape.ttl_toGlossary
+++ b/testing/infrastructure/VocabularyHubShape.ttl_toGlossary
@@ -24,7 +24,7 @@ shapes:VocabularyHubShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/infrastructure/VocabularyHubShape.ttl_toGlossary> (VocabularyHubShape): An ids:VocabularyHub is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/VocabularyHubShape.ttl_toGlossary> (VocabularyHubShape): An ids:VocabularyHub is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/participant/IndustrialClassificationShape.ttl
+++ b/testing/participant/IndustrialClassificationShape.ttl
@@ -27,7 +27,7 @@ shapes:IndustrialClassificationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/IndustrialClassificationShape.ttl> (IndustrialClassificationShape): An ids:IndustrialClassification is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/IndustrialClassificationShape.ttl> (IndustrialClassificationShape): An ids:IndustrialClassification is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/participant/ParticipantShape.ttl
+++ b/testing/participant/ParticipantShape.ttl
@@ -33,7 +33,7 @@ shapes:ParticipantShape
 		sh:class ids:Site ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:Participant must not have more than one ids:Site linked through the ids:primarySite property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:Participant must not have more than one ids:Site linked through the ids:primarySite property"@en ; 
 	] ;
 
 	sh:property [
@@ -42,7 +42,7 @@ shapes:ParticipantShape
 		sh:datatype xsd:string ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:Participant must have at least one xsd:string linked through the ids:corporateEmailAddress property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:Participant must have at least one xsd:string linked through the ids:corporateEmailAddress property"@en ; 
 	] ;
 
 	sh:property [
@@ -50,7 +50,7 @@ shapes:ParticipantShape
 		sh:path ids:corporateHomepage ;
 		sh:datatype xsd:anyURI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:corporateHomepage property must point from an ids:Participant to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:corporateHomepage property must point from an ids:Participant to an xsd:anyURI."@en ; 
 	] ;
 
 	sh:property [
@@ -58,7 +58,7 @@ shapes:ParticipantShape
 		sh:path ids:memberParticipant ;
 		sh:class ids:Participant ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:memberParticipant property must point from an ids:Participant to an ids:Participant."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:memberParticipant property must point from an ids:Participant to an ids:Participant."@en ; 
 	] ;
 
 	sh:property [
@@ -66,7 +66,7 @@ shapes:ParticipantShape
 		sh:path ids:industrialClassification ;
 		sh:class ids:IndustrialClassification ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:industrialClassification property must point from an ids:Participant to an ids:IndustrialClassification."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:industrialClassification property must point from an ids:Participant to an ids:IndustrialClassification."@en ; 
 	] ;
 
 	sh:property [
@@ -74,7 +74,7 @@ shapes:ParticipantShape
 		sh:path ids:participantCertification ;
 		sh:class ids:ParticipantCertification ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:participantCertification property must point from an ids:Participant to an ids:ParticipantCertification."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:participantCertification property must point from an ids:Participant to an ids:ParticipantCertification."@en ; 
 	] ;
 
 	sh:property [
@@ -82,7 +82,7 @@ shapes:ParticipantShape
 		sh:path ids:memberPerson ;
 		sh:class ids:Person ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:memberPerson property must point from an ids:Participant to an ids:Person."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:memberPerson property must point from an ids:Participant to an ids:Person."@en ; 
 	] .
 
 
@@ -95,7 +95,7 @@ shapes:PersonShape
 		sh:path ids:familyName ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:familyName property must point from an ids:Person to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:familyName property must point from an ids:Person to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -103,7 +103,7 @@ shapes:PersonShape
 		sh:path ids:givenName ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:givenName property must point from an ids:Person to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:givenName property must point from an ids:Person to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -111,7 +111,7 @@ shapes:PersonShape
 		sh:path ids:phoneNumber ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:phoneNumber property must point from an ids:Person to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:phoneNumber property must point from an ids:Person to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -119,7 +119,7 @@ shapes:PersonShape
 		sh:path ids:emailAddress ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:emailAddress property must point from an ids:Person to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:emailAddress property must point from an ids:Person to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -127,7 +127,7 @@ shapes:PersonShape
 		sh:path ids:homepage ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:homepage property must point from an ids:Person to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (PersonShape): An ids:homepage property must point from an ids:Person to an xsd:string."@en ; 
 	] .
 
 
@@ -140,6 +140,6 @@ shapes:SiteShape
 		sh:path ids:siteAddress ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/ParticipantShape.ttl> (SiteShape): An ids:siteAddress property must point from an ids:Site to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (SiteShape): An ids:siteAddress property must point from an ids:Site to an xsd:string."@en ; 
 	] .
 

--- a/testing/participant/RoleShape.ttl_toGlossary
+++ b/testing/participant/RoleShape.ttl_toGlossary
@@ -25,7 +25,7 @@ shapes:RoleShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/participant/RoleShape.ttl_toGlossary> (RoleShape): An ids:Role is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/RoleShape.ttl_toGlossary> (RoleShape): An ids:Role is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/security/AuthInfoShape.ttl
+++ b/testing/security/AuthInfoShape.ttl
@@ -29,7 +29,7 @@ shapes:AuthInfoShape
 		sh:path ids:authService ;
 		sh:class xsd:anyURI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/AuthInfoShape.ttl> (AuthInfoShape): An ids:authService property must point from an ids:AuthInfo to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/AuthInfoShape.ttl> (AuthInfoShape): An ids:authService property must point from an ids:AuthInfo to an xsd:anyURI."@en ; 
 	] ;
 
 	sh:property [
@@ -37,6 +37,6 @@ shapes:AuthInfoShape
 		sh:path ids:authStandard ;
 		sh:class ids:AuthStandard ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/AuthInfoShape.ttl> (AuthInfoShape): An ids:authStandard property must point from an ids:AuthInfo to an ids:AuthStandard."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/AuthInfoShape.ttl> (AuthInfoShape): An ids:authStandard property must point from an ids:AuthInfo to an ids:AuthStandard."@en ; 
 	] .
 

--- a/testing/security/SecurityProfileShape.ttl
+++ b/testing/security/SecurityProfileShape.ttl
@@ -28,7 +28,7 @@ shapes:SecurityProfileShape
 		sh:path ids:securityGuarantee ;
 		sh:class ids:SecurityGuarantee ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/SecurityProfileShape.ttl> (SecurityProfileShape): An ids:securityGuarantee property must point from an ids:SecurityProfile to an ids:SecurityGuarantee."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/SecurityProfileShape.ttl> (SecurityProfileShape): An ids:securityGuarantee property must point from an ids:SecurityProfile to an ids:SecurityGuarantee."@en ; 
 	] .
 
 #shapes:CustomSecurityProfileShape
@@ -40,6 +40,6 @@ shapes:SecurityProfileShape
 #		sh:path ids:securityGuarantee ;
 #		sh:class ids:SecurityGuarantee ;
 #		sh:severity sh:Violation ;
-#		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/SecurityProfileShape.ttl> (CustomSecurityProfileShape): An ids:securityGuarantee property must point from an ids:CustomSecurityProfile to an ids:SecurityGuarantee."@en ; 
+#		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/SecurityProfileShape.ttl> (CustomSecurityProfileShape): An ids:securityGuarantee property must point from an ids:CustomSecurityProfile to an ids:SecurityGuarantee."@en ; 
 #	] .
 

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -29,7 +29,7 @@ shapes:TokenShape
 		sh:path ids:tokenValue ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/TokenShape.ttl> (TokenShape): An ids:tokenValue property must point from an ids:Token to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): An ids:tokenValue property must point from an ids:Token to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -37,7 +37,7 @@ shapes:TokenShape
 		sh:path ids:tokenFormat ;
 		sh:class ids:TokenFormat ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/TokenShape.ttl> (TokenShape): An ids:tokenFormat property must point from an ids:Token to an ids:TokenFormat."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): An ids:tokenFormat property must point from an ids:Token to an ids:TokenFormat."@en ; 
 	] .
 
 
@@ -47,7 +47,7 @@ shapes:TokenFormatShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/security/TokenShape.ttl> (TokenFormatShape): An ids:TokenFormat is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenFormatShape): An ids:TokenFormat is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/shared/DescribedShape.ttl
+++ b/testing/shared/DescribedShape.ttl
@@ -33,7 +33,7 @@ shapes:DescribedShape
 		sh:path ids:title ;
 		sh:datatype rdf:PlainLiteral ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
 	] ;
 
 	sh:property [
@@ -41,7 +41,7 @@ shapes:DescribedShape
 		sh:path ids:description ;
 		sh:class ids:Concept ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to an ids:Concept."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to an ids:Concept."@en ; 
 	] ;
 	
 	sh:property [
@@ -49,6 +49,6 @@ shapes:DescribedShape
 		sh:path ids:comment ;
 		sh:datatype rdf:PlainLiteral ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:comment property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:comment property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
 	] .
 

--- a/testing/shared/NamedShape.ttl
+++ b/testing/shared/NamedShape.ttl
@@ -33,6 +33,6 @@ shapes:NamedShape
 		sh:path ids:name ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/shared/NamedShape.ttl> (NamedShape): An ids:name property must point from an ids:Named to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/NamedShape.ttl> (NamedShape): An ids:name property must point from an ids:Named to an xsd:string."@en ; 
 	] .
 

--- a/testing/taxonomies/CertificationShape.ttl
+++ b/testing/taxonomies/CertificationShape.ttl
@@ -27,6 +27,6 @@ shapes:ParticipantCertificationShape
 		sh:path ids:membershipEnd ;
 		sh:datatype xsd:date ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/CertificationShape.ttl> (ParticipantCertificationShape): An ids:membershipEnd property must point from an ids:ParticipantCertification to an xsd:date."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/CertificationShape.ttl> (ParticipantCertificationShape): An ids:membershipEnd property must point from an ids:ParticipantCertification to an xsd:date."@en ; 
 	] .
 

--- a/testing/taxonomies/DigitalContentShape.ttl
+++ b/testing/taxonomies/DigitalContentShape.ttl
@@ -31,7 +31,7 @@ shapes:SoftwareShape
 		sh:path ids:softwareInterface ;
 		sh:class ids:Interface ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/DigitalContentShape.ttl> (SoftwareShape): An ids:softwareInterface property must point from an ids:Software to an ids:Interface."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/DigitalContentShape.ttl> (SoftwareShape): An ids:softwareInterface property must point from an ids:Software to an ids:Interface."@en ; 
 	] ;
 
 	sh:property [
@@ -39,7 +39,7 @@ shapes:SoftwareShape
 		sh:path ids:icon ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/DigitalContentShape.ttl> (SoftwareShape): An ids:icon property must point from an ids:Software to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/DigitalContentShape.ttl> (SoftwareShape): An ids:icon property must point from an ids:Software to an xsd:string."@en ; 
 	] .
 
 
@@ -52,6 +52,6 @@ shapes:ListShape
 		sh:path ids:sortOrder ;
 		sh:class ids:SortOrder ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/DigitalContentShape.ttl> (ListShape): An ids:sortOrder property must point from an ids:List to an ids:SortOrder."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/DigitalContentShape.ttl> (ListShape): An ids:sortOrder property must point from an ids:List to an ids:SortOrder."@en ; 
 	] .
 

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -27,7 +27,7 @@ shapes:RequestMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (RequestMessageShape): An ids:RequestMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RequestMessageShape): An ids:RequestMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:ResponseMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:ResponseMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:ResponseMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -63,7 +63,7 @@ shapes:ResponseMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
 	] .
 
 
@@ -73,7 +73,7 @@ shapes:NotificationMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (NotificationMessageShape): An ids:NotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (NotificationMessageShape): An ids:NotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -91,7 +91,7 @@ shapes:CommandMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (CommandMessageShape): An ids:CommandMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (CommandMessageShape): An ids:CommandMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -109,7 +109,7 @@ shapes:QueryMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:QueryMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:QueryMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -130,7 +130,7 @@ shapes:RejectionMessageShape
 		sh:path ids:rejectionReason ;
 		sh:class ids:RejectionReason ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (RejectionMessageShape): An ids:rejectionReason property must point from an ids:RejectionMessage to an ids:RejectionReason."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RejectionMessageShape): An ids:rejectionReason property must point from an ids:RejectionMessage to an ids:RejectionReason."@en ; 
 	] .
 
 
@@ -140,7 +140,7 @@ shapes:ConnectorRuntimeNotificationMessageShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:ConnectorRuntimeNotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:ConnectorRuntimeNotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -156,7 +156,7 @@ shapes:ConnectorRuntimeNotificationMessageShape
 		sh:path ids:affectedConnector ;
 		sh:class ids:Connector ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:affectedConnector property must point from an ids:ConnectorRuntimeNotificationMessage to an ids:Connector."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:affectedConnector property must point from an ids:ConnectorRuntimeNotificationMessage to an ids:Connector."@en ; 
 	] .
 
 
@@ -169,7 +169,7 @@ shapes:BrokerQueryMessageShape
 		sh:path ids:brokerQueryScope ;
 		sh:class ids:BrokerQueryScope ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:brokerQueryScope property must point from an ids:BrokerQueryMessage to an ids:BrokerQueryScope."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:brokerQueryScope property must point from an ids:BrokerQueryMessage to an ids:BrokerQueryScope."@en ; 
 	] ;
 
 	sh:property [
@@ -177,7 +177,7 @@ shapes:BrokerQueryMessageShape
 		sh:path ids:queryLanguage ;
 		sh:class ids:QueryLanguage ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:queryLanguage property must point from an ids:BrokerQueryMessage to an ids:QueryLanguage."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:queryLanguage property must point from an ids:BrokerQueryMessage to an ids:QueryLanguage."@en ; 
 	] .
 
 
@@ -192,7 +192,7 @@ shapes:ContractRequestMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ContractRequestMessageShape): An ids:ContractRequestMessage must have exactly one ids:ContractOffer linked through the ids:baseContractOffer property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRequestMessageShape): An ids:ContractRequestMessage must have exactly one ids:ContractOffer linked through the ids:baseContractOffer property"@en ; 
 	] .
 
 
@@ -205,7 +205,7 @@ shapes:ContractRejectionMessageShape
 		sh:path ids:contractRejectionReason ;
 		sh:datatype rdf:PlainLiteral ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to an rdf:PlainLiteral."@en ; 
 	] .
 
 
@@ -220,7 +220,7 @@ shapes:ArtifactAvailableMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ArtifactAvailableMessageShape): An ids:ArtifactAvailableMessage must have exactly one ids:Artifact linked through the ids:availableArtifact property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactAvailableMessageShape): An ids:ArtifactAvailableMessage must have exactly one ids:Artifact linked through the ids:availableArtifact property"@en ; 
 	] .
 
 
@@ -235,7 +235,7 @@ shapes:InvokeOperationMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have exactly one ids:Operation linked through the ids:operationReference property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have exactly one ids:Operation linked through the ids:operationReference property"@en ; 
 	] ;
 
 	sh:property [
@@ -244,7 +244,7 @@ shapes:InvokeOperationMessageShape
 		sh:datatype ids:ParameterAssignment ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have at least one ids:ParameterAssignment linked through the ids:operationParameterization property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have at least one ids:ParameterAssignment linked through the ids:operationParameterization property"@en ; 
 	] .
 
 
@@ -259,7 +259,7 @@ shapes:RequestInProcessMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (RequestInProcessMessageShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RequestInProcessMessageShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
 	] .
 
 
@@ -274,7 +274,7 @@ shapes:MessageProcessedNotificationShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationShape): An ids:Message must have exactly one ids:Message linked through the ids:correlationMessage property"@en ; 
 	] .
 
 
@@ -289,6 +289,6 @@ shapes:ArtifactRequestMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ArtifactRequestMessage must have exactly one ids:Artifact linked through the ids:requestedArtifact property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ArtifactRequestMessage must have exactly one ids:Artifact linked through the ids:requestedArtifact property"@en ; 
 	] .
 

--- a/testing/taxonomies/OperationShape.ttl
+++ b/testing/taxonomies/OperationShape.ttl
@@ -27,7 +27,7 @@ shapes:CommandOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (CommandOperationShape): An ids:CommandOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (CommandOperationShape): An ids:CommandOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -45,7 +45,7 @@ shapes:QueryOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (QueryOperationShape): An ids:QueryOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (QueryOperationShape): An ids:QueryOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -63,7 +63,7 @@ shapes:SortingOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (SortingOperationShape): An ids:SortingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (SortingOperationShape): An ids:SortingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -81,7 +81,7 @@ shapes:ClientPaginatingOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (ClientPaginatingOperationShape): An ids:ClientPaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (ClientPaginatingOperationShape): An ids:ClientPaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -99,7 +99,7 @@ shapes:ServerAbsolutePaginatingOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (ServerAbsolutePaginatingOperationShape): An ids:ServerAbsolutePaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (ServerAbsolutePaginatingOperationShape): An ids:ServerAbsolutePaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -117,7 +117,7 @@ shapes:ServerRelativePaginatingOperationShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/OperationShape.ttl> (ServerRelativePaginatingOperationShape): An ids:ServerRelativePaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/OperationShape.ttl> (ServerRelativePaginatingOperationShape): An ids:ServerRelativePaginatingOperation is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type

--- a/testing/taxonomies/RepresentationShape.ttl
+++ b/testing/taxonomies/RepresentationShape.ttl
@@ -30,7 +30,7 @@ shapes:DataRepresentationShape
 		sh:path ids:dataType ;
 		sh:datatype xsd:anyURI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataType property must point from an ids:DataRepresentation to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataType property must point from an ids:DataRepresentation to an xsd:anyURI."@en ; 
 	] ;
 
 	sh:property [
@@ -38,7 +38,7 @@ shapes:DataRepresentationShape
 		sh:path ids:dataTypeSchema ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataTypeSchema property must point from an ids:DataRepresentation to an ids:Resource."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataTypeSchema property must point from an ids:DataRepresentation to an ids:Resource."@en ; 
 	] .
 
 
@@ -51,7 +51,7 @@ shapes:AudioRepresentationShape
 		sh:path ids:samplingRate ;
 		sh:datatype xsd:decimal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (AudioRepresentationShape): An ids:samplingRate property must point from an ids:AudioRepresentation to an xsd:decimal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (AudioRepresentationShape): An ids:samplingRate property must point from an ids:AudioRepresentation to an xsd:decimal."@en ; 
 	] .
 
 
@@ -64,7 +64,7 @@ shapes:ImageRepresentationShape
 		sh:path ids:width ;
 		sh:datatype xsd:decimal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (ImageRepresentationShape): An ids:width property must point from an ids:ImageRepresentation to an xsd:decimal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (ImageRepresentationShape): An ids:width property must point from an ids:ImageRepresentation to an xsd:decimal."@en ; 
 	] ;
 
 	sh:property [
@@ -72,7 +72,7 @@ shapes:ImageRepresentationShape
 		sh:path ids:height ;
 		sh:datatype xsd:decimal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (ImageRepresentationShape): An ids:height property must point from an ids:ImageRepresentation to an xsd:decimal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (ImageRepresentationShape): An ids:height property must point from an ids:ImageRepresentation to an xsd:decimal."@en ; 
 	] .
 
 
@@ -85,6 +85,6 @@ shapes:VideoRepresentationShape
 		sh:path ids:frameRate ;
 		sh:datatype xsd:decimal ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/taxonomies/RepresentationShape.ttl> (VideoRepresentationShape): An ids:frameRate property must point from an ids:VideoRepresentation to an xsd:decimal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (VideoRepresentationShape): An ids:frameRate property must point from an ids:VideoRepresentation to an xsd:decimal."@en ; 
 	] .
 

--- a/testing/traceability/ActivityShape.ttl
+++ b/testing/traceability/ActivityShape.ttl
@@ -28,7 +28,7 @@ shapes:ActivityShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:Activity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:Activity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -44,7 +44,7 @@ shapes:ActivityShape
 		sh:path ids:activityDescription ;
 		sh:datatype rdf:PlainLiteral ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to an rdf:PlainLiteral."@en ; 
 	] ;
 
 	sh:property [
@@ -53,7 +53,7 @@ shapes:ActivityShape
 		sh:class ids:Participant ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:Activity must not have more than one ids:Participant linked through the ids:startedBy property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:Activity must not have more than one ids:Participant linked through the ids:startedBy property"@en ; 
 	] ;
 
 	sh:property [
@@ -61,7 +61,7 @@ shapes:ActivityShape
 		sh:path ids:startedAt ;
 		sh:datatype xsd:dateTime ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:startedAt property must point from an ids:Activity to an xsd:dateTime."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:startedAt property must point from an ids:Activity to an xsd:dateTime."@en ; 
 	] ;
 
 	sh:property [
@@ -69,7 +69,7 @@ shapes:ActivityShape
 		sh:path ids:endedBy ;
 		sh:class ids:Participant ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:endedBy property must point from an ids:Activity to an ids:Participant."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:endedBy property must point from an ids:Activity to an ids:Participant."@en ; 
 	] ;
 
 	sh:property [
@@ -77,7 +77,7 @@ shapes:ActivityShape
 		sh:path ids:endedAt ;
 		sh:datatype xsd:dateTime ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:endedAt property must point from an ids:Activity to an xsd:dateTime."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:endedAt property must point from an ids:Activity to an xsd:dateTime."@en ; 
 	] .
 
 
@@ -90,6 +90,6 @@ shapes:ModificationActivityShape
 		sh:path ids:invalidated ;
 		sh:datatype ids:ManagedEntity ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ActivityShape.ttl> (ModificationActivityShape): An ids:invalidated property must point from an ids:ModificationActivity to an ids:ManagedEntity."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ModificationActivityShape): An ids:invalidated property must point from an ids:ModificationActivity to an ids:ManagedEntity."@en ; 
 	] .
 

--- a/testing/traceability/ManagedEntityShape.ttl
+++ b/testing/traceability/ManagedEntityShape.ttl
@@ -28,7 +28,7 @@ shapes:ManagedEntityShape
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:ManagedEntity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:ManagedEntity is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
@@ -44,7 +44,7 @@ shapes:ManagedEntityShape
 		sh:path ids:lifecycleActivity ;
 		sh:class ids:Activity ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:lifecycleActivity property must point from an ids:ManagedEntity to an ids:Activity."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:lifecycleActivity property must point from an ids:ManagedEntity to an ids:Activity."@en ; 
 	] ;
 
 	sh:property [
@@ -52,6 +52,6 @@ shapes:ManagedEntityShape
 		sh:path ids:version ;
 		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://github.com/IndustrialDataSpace/InformationModel/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:version property must point from an ids:ManagedEntity to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ManagedEntityShape.ttl> (ManagedEntityShape): An ids:version property must point from an ids:ManagedEntity to an xsd:string."@en ; 
 	] .
 


### PR DESCRIPTION
I replaced the links to point to raw resources "raw.githubusercontent.com/..."
Note that the links contain the branch name, so I used master. Obviously this won't work until we merge dev into master.

The @prefix shapes are still pointing to the original <https://github.com/IndustrialDataSpace/InformationModel/testing/> -- I would assume this is okay, as I doubt we can use a raw link for a directory (yields 400: Invalid Request).
Please share your thoughts