### PR TITLE
Some improvements to the BinaryOperators

### DIFF
--- a/codes/BinaryOperators.ttl
+++ b/codes/BinaryOperators.ttl
@@ -33,7 +33,7 @@ idsc:GT a ids:BinaryOperator;
     
 idsc:LTEQ a ids:BinaryOperator;
     rdfs:seeAlso odrl:lteq;
-    rdfs:label "less than ot equals"@en ;
+    rdfs:label "less than or equals"@en ;
     rdfs:comment "Less-than-or-equals operator. Can be used for numeric (2 idsc:LTEQ 5) or qualitative comparisons (idsc:INTEGRITY_PROTECTION_NONE idsc:LTEQ idsc:INTEGRITY_VERIFICATION_REMOTE)."@en ;
     .
     

--- a/codes/BinaryOperators.ttl
+++ b/codes/BinaryOperators.ttl
@@ -16,30 +16,30 @@
 # Generic operators
 idsc:EQ a ids:BinaryOperator;
     rdfs:seeAlso odrl:eq;
-    rdfs:label "equals";
+    rdfs:label "equals"@en ;
     rdfs:comment "Equals operator. Actual semantic depends on the related LeftOperand. For instance, idsc:NOW (time:TimeInstance) requires a comparison of temporal instances while idsc:count demands a numeric comparison."@en ;
     .
     
 idsc:GTEQ a ids:BinaryOperator;
     rdfs:seeAlso odrl:gteq;
-    rdfs:label "greater than or equals";
-    rdfs:comment "Greater-or-equals-than operator. Can be used for numeric (5 idsc:GTEQ 2) or qualitative comparisons (idsc:INTEGRITY_VERIFICATION_REMOTE idsc:gteq idsc:INTEGRITY_PROTECTION_NONE)."@en .
+    rdfs:label "greater than or equals"@en ;
+    rdfs:comment "Greater-than-or-equals operator. Can be used for numeric (5 idsc:GTEQ 2) or qualitative comparisons (idsc:INTEGRITY_VERIFICATION_REMOTE idsc:gteq idsc:INTEGRITY_PROTECTION_NONE)."@en .
     
 idsc:GT a ids:BinaryOperator;
     rdfs:seeAlso odrl:gt;
-    rdfs:label "greater than";
+    rdfs:label "greater than"@en ;
     rdfs:comment "Greater-than operator. Can be used for numeric (5 idsc:GT 2) or qualitative comparisons (idsc:INTEGRITY_VERIFICATION_REMOTE idsc:GT idsc:INTEGRITY_PROTECTION_NONE)."@en ;
     .
     
 idsc:LTEQ a ids:BinaryOperator;
     rdfs:seeAlso odrl:lteq;
-    rdfs:label "less than ot equals";
+    rdfs:label "less than ot equals"@en ;
     rdfs:comment "Less-than-or-equals operator. Can be used for numeric (2 idsc:LTEQ 5) or qualitative comparisons (idsc:INTEGRITY_PROTECTION_NONE idsc:LTEQ idsc:INTEGRITY_VERIFICATION_REMOTE)."@en ;
     .
     
 idsc:LT a ids:BinaryOperator;
     rdfs:seeAlso odrl:lt;
-    rdfs:label "less";
+    rdfs:label "less than"@en ;
     rdfs:comment "Less-than operator. Can be used for numeric (2 idsc:LT 5) or qualitative comparisons (idsc:INTEGRITY_PROTECTION_NONE idsc:LT idsc:INTEGRITY_VERIFICATION_REMOTE)."@en ;
     .
     
@@ -52,28 +52,26 @@ idsc:IN a ids:BinaryOperator;
 # Temporal operators
 idsc:AFTER a ids:BinaryOperator;
     rdfs:seeAlso time:after;
-    rdfs:label "after";
+    rdfs:label "after"@en ;
     rdfs:comment "If a temporal entity T1 is after another temporal entity T2, then the beginning of T1 is after the end of T2. Temporal entities can either be a xsd:dateTime (time:TimeInstance) or a ids:TemporalEntity ([ ids:begin {xsd:dateTime}; ids:end {xsd:dateTime} ])."@en ;
     .
     
 idsc:BEFORE a ids:BinaryOperator;
     rdfs:seeAlso time:before ;
-    rdfs:label "before" ;
+    rdfs:label "before"@en ;
     rdfs:comment "If a temporal entity T1 is before another temporal entity T2, then the ending of T1 is before the end of T2. Temporal entities can either be a xsd:dateTime (time:TimeInstance) or a ids:TemporalEntity ([ ids:begin {xsd:dateTime}; ids:end {xsd:dateTime} ])."@en ;
     .
     
 idsc:IN_TIME_INTERVAL a ids:BinaryOperator;
-    owl:inverseOf time:inside ;
-    rdfs:label "in time interval";
-    rdfs:comment "Specifies that a given time point is inside a given ids:TemporalEntity. Recommended pattern for temporal intervals is [ ids:begin {xsd:dateTime}; ids:end {xsd:dateTime} ].".
+    rdfs:seeAlso time:inside ;
+    rdfs:label "in time interval"@en ;
+    rdfs:comment "Specifies that a given time point is inside a given ids:TemporalEntity. Recommended pattern for temporal intervals is [ ids:begin {xsd:dateTime}; ids:end {xsd:dateTime} ]."@en ;
+	.
     
 
 # role-based
 idsc:HAS_ROLE a ids:BinaryOperator;
     rdfs:seeAlso odrl:isAnyOf ;
-    rdfs:label "has Role" ;
+    rdfs:label "has Role"@en ;
     rdfs:comment "If a user has a specific role required for accessing a resource. Must be used together with a RightOperand of type xsd:anyUri which should point to an accessible endpoint providing this information."@en ;
     .
-    
-
-    


### PR DESCRIPTION
Some modifications, mostly minor for consistency.

However, I would like to question the following triples:

```
idsc:HAS_ROLE a ids:BinaryOperator;
    rdfs:seeAlso odrl:isAnyOf ;
```

Is idsc:HAS_ROLE really sort of described by odrl:isAnyOf?