### PR TITLE
Removing duplicate class ids:Concept from Described

### DIFF
--- a/model/shared/Described.ttl
+++ b/model/shared/Described.ttl
@@ -13,12 +13,11 @@
 # -------
 
 
-#creating this helper class to prevent errors in codegen tool.
-#TODO: This class should be removed and ids:description should have skos:Concept as range
-ids:Concept
-	a owl:Class ;
-	rdfs:subClassOf skos:Concept ;
-	rdfs:label "Concept"@en .
+### Removing this class, as it is already defined in model/content/Concept.ttl
+#ids:Concept
+#	a owl:Class ;
+#	rdfs:subClassOf skos:Concept ;
+#	rdfs:label "Concept"@en .
 
 
 


### PR DESCRIPTION
ids:Concept is also defined in model/content/Concept.ttl so we should remove this duplicate.