### PR TITLE
Switching range of ids:referingConnector to string

### DIFF
--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -60,10 +60,10 @@ ids:TokenFormat a owl:Class;
 
 
 
-ids:referingConnector a owl:ObjectProperty;
+ids:referingConnector a owl:DatatypeProperty;
     rdfs:label "referingConnector"@en;
     rdfs:domain ids:Token;
-    rdfs:range xsd:string ; # xsd:base64Binary;
+    rdfs:range xsd:anyURI ; # xsd:base64Binary;
     rdfs:comment "The RDF connector entity as referred to by the DAT. The value MUST be its accessible URI. Must contain at least one SecurityProfile claim."@en.
 
 ids:aud a owl:DatatypeProperty;

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -63,8 +63,8 @@ ids:TokenFormat a owl:Class;
 ids:referingConnector a owl:ObjectProperty;
     rdfs:label "referingConnector"@en;
     rdfs:domain ids:Token;
-    rdfs:range ids:Connector ; # xsd:base64Binary;
-    rdfs:comment "The RDF connector entity as referred to by the DAT. Must contain at least one SecurityProfile claim."@en.
+    rdfs:range xsd:string ; # xsd:base64Binary;
+    rdfs:comment "The RDF connector entity as referred to by the DAT. The value MUST be its accessible URI. Must contain at least one SecurityProfile claim."@en.
 
 ids:aud a owl:DatatypeProperty;
     rdfs:label "aud"@en;


### PR DESCRIPTION
ids:referingConnector ...  rdfs:range ids:Connector ...  results in a complete new Connector instance (with all its attributes, ant further links) at this position. However, only a reference was intended. The quick solution is to change the range now to xsd:string while also anyUri or other datatypes might be possible.