### PR TITLE
fix typo in validation property for ResourceNotificationMessage

### DIFF
--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -280,7 +280,7 @@ ids:ResourceNotificationMessage a owl:Class;
     rdfs:label "Resource Notification Message"@en ;
     rdfs:comment "Superclass of all messages, indicating a change of a resource."@en;
 	idsm:validation [
-        idsm:forProperty ids:availableResource;
+        idsm:forProperty ids:affectedResource;
         idsm:constraint idsm:NotNull;
     ].
 


### PR DESCRIPTION
The idsm:validation property of ResourceNotificationMessage referenced a non-existing  property.

Now points to correct property.