### PR TITLE
remove redundant property from ContractRequestMessage

### DIFF
--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -212,17 +212,7 @@ ids:ContractRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
     rdfs:label "Contract Request Message"@en;
     rdfs:comment "Message containing a suggested content contract (as offered by the data consumer to the data provider) in the associated payload (which is an instance of ContractRequest)."@en;
-    idsm:validation [
-        idsm:forProperty ids:baseContractOffer;
-        idsm:constraint idsm:NotNull;
-    ].
-
-ids:baseContractOffer a owl:ObjectProperty;
-    rdfs:label "Base Contract Offer"@en ;
-    idsm:referenceByUri true;
-    rdfs:domain ids:ContractRequestMessage;
-    rdfs:range ids:ContractOffer;
-    rdfs:comment "The basic offered contract that the contract request message refers to."@en.
+    .
 
 ids:ContractOfferMessage a owl:Class ;
     rdfs:subClassOf ids:NotificationMessage, ids:ResponseMessage ;


### PR DESCRIPTION
### Problem:
The **ids:ContractRequestMessage** has a property called _ids:baseContractOffer_ which refers to a **ids:ContractOffer** (which is wrong, it should be an ids:ContractRequest, but that's not the problem).

Per definition, the **ids:ContractRequestMessage** should contain the Contract in it's payload. Therefore, we don't need the, above mentioned, property _ids:baseContractOffer_.

The other Contract-related Messages 
- ids:ContractAgreementMessage
- ids:ContractOfferMessage
do not have such a property, although they are used in a similar way.

### Suggestion: 
Remove property _ids:baseContractOffer_