### PR TITLE
Add sender and recipient Agents to ids:Connector

### DIFF
--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -29,11 +29,7 @@ ids:Connector
         idsm:relationType idsm:OneToMany;
     ]; 
     idsm:validation [
-        idsm:forProperty ids:senderAgent;
-        idsm:relationType idsm:OneToMany;
-    ]; 
-    idsm:validation [
-        idsm:forProperty ids:recipientAgent;
+        idsm:forProperty ids:hasAgents;
         idsm:relationType idsm:OneToMany;
     ].
 
@@ -95,18 +91,10 @@ ids:catalog a owl:ObjectProperty;
     rdfs:label "catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 
-ids:senderAgent
+ids:hasAgents
     a owl:DatatypeProperty;
     idsm:referenceByUri true;
     rdfs:label "sender agent"@en;
     rdfs:domain ids:Connector;
     rdfs:range ids:Agent;
-    rdfs:comment "The Agent for which this Connector may initiate a Message."@en.
-
-ids:recipientAgent
-    a owl:DatatypeProperty;
-    idsm:referenceByUri true;
-    rdfs:label "recipient agent"@en;
-    rdfs:domain ids:Connector;
-    rdfs:range ids:Agent;
-    rdfs:comment "The Agent for which this Connecotr is able to receive a Mesaage."@en.
+    rdfs:comment "The Agents for which this Connector may initiate and receive Messages."@en.

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -49,7 +49,6 @@ ids:TrustedConnector rdfs:subClassOf ids:Connector ;
 ids:host
     a owl:ObjectProperty;
     rdfs:label "host"@en;
-    idsm:labelPluralForm "hosts"@en;
     rdfs:domain ids:Connector;
     rdfs:range ids:Host;
     rdfs:comment "Networked host operated by the Connector in order to serve and consume resource content and services."@en.
@@ -91,10 +90,9 @@ ids:catalog a owl:ObjectProperty;
     rdfs:label "catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 
-ids:hasAgents
-    a owl:DatatypeProperty;
+ids:hasAgents a owl:ObjectProperty;
     idsm:referenceByUri true;
-    rdfs:label "sender agent"@en;
+    rdfs:label "has Agents"@en;
     rdfs:domain ids:Connector;
     rdfs:range ids:Agent;
     rdfs:comment "The Agents for which this Connector may initiate and receive Messages."@en.

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -27,6 +27,14 @@ ids:Connector
     idsm:validation [
         idsm:forProperty ids:transportCertsSha256;
         idsm:relationType idsm:OneToMany;
+    ]; 
+    idsm:validation [
+        idsm:forProperty ids:senderAgent;
+        idsm:relationType idsm:OneToMany;
+    ]; 
+    idsm:validation [
+        idsm:forProperty ids:recipientAgent;
+        idsm:relationType idsm:OneToMany;
     ].
 
 ids:BaseConnector rdfs:subClassOf ids:Connector ;
@@ -86,3 +94,19 @@ ids:catalog a owl:ObjectProperty;
     rdfs:range ids:Catalog;
     rdfs:label "catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
+
+ids:senderAgent
+    a owl:DatatypeProperty;
+    idsm:referenceByUri true;
+    rdfs:label "sender agent"@en;
+    rdfs:domain ids:Connector;
+    rdfs:range ids:Agent;
+    rdfs:comment "The Agent for which this Connector may initiate a Message."@en.
+
+ids:recipientAgent
+    a owl:DatatypeProperty;
+    idsm:referenceByUri true;
+    rdfs:label "recipient agent"@en;
+    rdfs:domain ids:Connector;
+    rdfs:range ids:Agent;
+    rdfs:comment "The Agent for which this Connecotr is able to receive a Mesaage."@en.


### PR DESCRIPTION
Adding feature for specifying Agents in the Connector SelfDescription as described in #163 