### PR TITLE
Change ids:ParIS subclassOf property to ids:Connector

### DIFF
--- a/model/infrastructure/ParIS.ttl
+++ b/model/infrastructure/ParIS.ttl
@@ -9,7 +9,7 @@
 
 ids:ParIS
     a owl:Class;
-    rdfs:subClassOf ids:InfrastructureComponent;
+    rdfs:subClassOf ids:Connector;
     rdfs:label "Participant Information Service"@en ;
     rdfs:comment "The Participant Information Service (ParIS) provides metadata and relevant information about participants (humans and organizations) in the International Data Spaces."@en .
 


### PR DESCRIPTION
ids:ParIS is now subclass of ids:Connector and inherits the properties of ids:Connector, similar to the ids:Broker class.

