### PR TITLE
Changing shacl shape of nonNegativeInteger

### DIFF
--- a/testing/content/ArtifactShape.ttl
+++ b/testing/content/ArtifactShape.ttl
@@ -29,11 +29,13 @@ shapes:ArtifactShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:byteSize ;
-		sh:datatype xsd:nonNegativeInteger ;
+		sh:datatype xsd:integer ;
 		sh:maxCount 1 ;
+		sh:minInclusive 0 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ArtifactShape.ttl> (ArtifactShape): An ids:Artifact must not have more than one xsd:nonNegativeInteger linked through the ids:byteSize property"@en ; 
 	] ;
+
 
 	sh:property [
 		a sh:PropertyShape ;


### PR DESCRIPTION
While performing validations on messages sent/received to/from the broker, I discovered that the values of byteSize of Artifacts are, while non-negative, being parsed as xsd:Integer. This caused the shacl validation to throw errors.

Hence, I switched the shape to allow for integers (this should also allow nonNegativeIntegers), while adding another condition to require >= 0 value.