### PR TITLE
Fix/message names

### DIFF
--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -121,7 +121,7 @@ ids:ConnectorCertificateRevokedMessage a owl:Class;
 
 ids:affectedConnector a owl:ObjectProperty;
     idsm:referenceByUri true;
-    rdfs:label "affectedConnector"@en;
+    rdfs:label "affected Connector"@en;
     rdfs:domain ids:ConnectorNotificationMessage;
     rdfs:range ids:Connector;
     rdfs:comment "References the connector that is affected by the runtime condition change."@en.
@@ -171,7 +171,7 @@ ids:affectedParticipant a owl:ObjectProperty;
     rdfs:range ids:Participant;
     rdfs:comment "References the participant that is referenced in the participant-related notification messages."@en.
 
-ids:revokeReason
+ids:revocationReason 
     a owl:DatatypeProperty;
     rdfs:label "revoke reason"@en;
     rdfs:domain [ owl:unionOf (
@@ -180,7 +180,7 @@ ids:revokeReason
             )
         ];
     rdfs:range xsd:string;
-    rdfs:comment "Plain Text containing the reason for revoking an existing certificate of an infrastructure component, e.g. a connector or participant."@en.
+    rdfs:comment "Plain Text containing the reason for revoking an existing certificate of either a connector or participant."@en.
 
 # Query related Messages
 # -----------------------

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -60,14 +60,14 @@ ids:rejectionReason a owl:ObjectProperty;
 # Self-description Access
 # -----------------------
 
-ids:SelfDescriptionRequest a owl:Class;
+ids:SelfDescriptionRequestMessage a owl:Class;
     rdfs:subClassOf ids:RequestMessage ;
-    rdfs:label "Self Description Request"@en ;
+    rdfs:label "Self Description Request Message"@en ;
     rdfs:comment "Message requesting the self-description of an Infrastructure Component."@en.
 
-ids:SelfDescriptionResponse a owl:Class ;
+ids:SelfDescriptionResponseMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage ;
-    rdfs:label "Self Description Response"@en ;
+    rdfs:label "Self Description Response Message"@en ;
     rdfs:comment "Message containing the self-description of an Infrastructure Component."@en.
 
 # Connector-related Messages
@@ -124,13 +124,6 @@ ids:ParticipantNotificationMessage a owl:Class;
     rdfs:label "Participant Notification Message"@en ;
     rdfs:comment "Superclass of all messages, indicating a change of a particpants's conditions."@en.
 
-ids:affectedParticipant a owl:ObjectProperty;
-    idsm:referenceByUri true;
-    rdfs:label "affected Participant"@en;
-    rdfs:domain ids:ParticipantNotificationMessage;
-    rdfs:range ids:Participant;
-    rdfs:comment "References the participant that is referenced in the participant-related notification messages."@en.
-
 ids:ParticipantAvailableMessage a owl:Class;
     rdfs:subClassOf ids:ParticipantNotificationMessage ;
     rdfs:label "Participant Available Message"@en ;
@@ -156,10 +149,17 @@ ids:ParticipantUpdateMessage a owl:Class;
     rdfs:label "Participant Information Changed Message"@en ;
     rdfs:comment "Event notifying the recipient(s) that information describing this Participant has changed. This event is mainly intended for information describing the Participant that is NOT a direct subject of the certification process."@en.
 
+ids:affectedParticipant a owl:ObjectProperty;
+    idsm:referenceByUri true;
+    rdfs:label "affected Participant"@en;
+    rdfs:domain ids:ParticipantNotificationMessage;
+    rdfs:range ids:Participant;
+    rdfs:comment "References the participant that is referenced in the participant-related notification messages."@en.
+
 ids:revokeReason
     a owl:DatatypeProperty;
     rdfs:label "revoke reason"@en;
-    rdfs:domain ids:ConnectorCertificateRevokedMessage; # TODO: , ids:ParticipantCertificateRevokedMessage ;
+    rdfs:domain ids:ConnectorCertificateRevokedMessage, ids:ParticipantCertificateRevokedMessage ;
     rdfs:range xsd:string;
     rdfs:comment "Plain Text containing the reason for revoking an existing certificate of an infrastructure component, e.g. a connector or participant."@en.
 
@@ -247,9 +247,9 @@ ids:agreedContract a owl:ObjectProperty;
 # Security-related Messages
 # -------------------------
 
-ids:AccessTokenRequest a owl:Class ;
+ids:AccessTokenRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
-    rdfs:label "Access Token Request"@en;
+    rdfs:label "AccessToken Request Message"@en;
     rdfs:comment "Message requesting an access token. This is intended for point-to-point communication with, e.g., Brokers."@en.
 
 ids:AccessTokenResponse a owl:Class ;
@@ -328,9 +328,9 @@ ids:RequestInProcessMessage a owl:Class ;
         idsm:constraint idsm:NotNull;
     ].
 
-ids:MessageProcessedNotification a owl:Class ;
+ids:MessageProcessedNotificationMessage a owl:Class ;
     rdfs:subClassOf ids:NotificationMessage;
-    rdfs:label "Message Processed Notification"@en;
+    rdfs:label "Message Processed Notification Message"@en;
     rdfs:comment "Notification that a message has been successfully processed (i.e. not ignored or rejected)."@en;
     idsm:validation [
         idsm:forProperty ids:correlationMessage;
@@ -393,8 +393,8 @@ ids:ParticipantResponseMessage a owl:Class ;
 # Log messaging
 # -------------
 
-ids:LogNotification a owl:Class;
+ids:LogMessage a owl:Class;
     rdfs:subClassOf ids:NotificationMessage ;
-    rdfs:label "Log Notification"@en ;
-    rdfs:comment "Log notification which can be used to transfer logs e.g. to the clearing house."@en.
+    rdfs:label "Log Message"@en ;
+    rdfs:comment "Log Message which can be used to transfer logs e.g. to the clearing house."@en.
 

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -173,7 +173,7 @@ ids:affectedParticipant a owl:ObjectProperty;
 
 ids:revocationReason 
     a owl:DatatypeProperty;
-    rdfs:label "revoke reason"@en;
+    rdfs:label "Revocation Reason"@en;
     rdfs:domain [ owl:unionOf (
             ids:ConnectorCertificateRevokedMessage
             ids:ParticipantCertificateRevokedMessage

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -9,8 +9,9 @@
 # Classes
 # -------
 
-# Basic Message Types
-# -------------------
+# Basic Message Types: Request, Response, Notification
+# May be used direcoty for non-core IDS scenarios. 
+# -----------------------------------------------------
 
 ids:RequestMessage a owl:Class;
     rdfs:subClassOf ids:Message ;
@@ -30,6 +31,11 @@ ids:NotificationMessage a owl:Class ;
     rdfs:subClassOf ids:Message ;
     rdfs:label "Notification Message"@en ;
     rdfs:comment "Event messages are informative and no response is expected by the sender."@en.
+
+
+# Core IDS Messages
+# -----------------
+
 
 ids:CommandMessage a owl:Class;
     rdfs:subClassOf ids:RequestMessage ;
@@ -57,8 +63,8 @@ ids:rejectionReason a owl:ObjectProperty;
     rdfs:label "rejectionReason"@en;
     rdfs:comment "Specifies the reason of the rejection."@en.
 
-# Self-description Access
-# -----------------------
+# Self-Description
+# -----------------
 
 ids:SelfDescriptionRequestMessage a owl:Class;
     rdfs:subClassOf ids:RequestMessage ;
@@ -77,13 +83,11 @@ ids:ConnectorNotificationMessage a owl:Class;
     rdfs:subClassOf ids:NotificationMessage ;
     idsm:abstract true ;
     rdfs:label "Connector Notification Message"@en ;
-    rdfs:comment "Superclass of all messages, indicating a change of a connector's conditions."@en.
-
-ids:affectedConnector a owl:ObjectProperty;
-    rdfs:label "affectedConnector"@en;
-    rdfs:domain ids:ConnectorNotificationMessage;
-    rdfs:range ids:Connector;
-    rdfs:comment "References the connector that is affected by the runtime condition change."@en.
+    rdfs:comment "Superclass of all messages, indicating a change of a connector's conditions."@en;
+    idsm:validation [
+        idsm:forProperty ids:affectedConnector;
+        idsm:constraint idsm:NotNull;
+    ].
 
 ids:ConnectorAvailableMessage a owl:Class;
     rdfs:subClassOf ids:ConnectorNotificationMessage ;
@@ -115,6 +119,12 @@ ids:ConnectorCertificateRevokedMessage a owl:Class;
 	rdfs:label "Connector Certificate Revoked Message"@en ;
 	rdfs:comment "Indicates that a (previously certified) Connector is no more certified. This could happen, for instance, if the Certification Body revokes a granted certificate or if the certificate just expires."@en.
 
+ids:affectedConnector a owl:ObjectProperty;
+    idsm:referenceByUri true;
+    rdfs:label "affectedConnector"@en;
+    rdfs:domain ids:ConnectorNotificationMessage;
+    rdfs:range ids:Connector;
+    rdfs:comment "References the connector that is affected by the runtime condition change."@en.
 
 # Participant-related Messages
 # ----------------------------
@@ -122,7 +132,12 @@ ids:ParticipantNotificationMessage a owl:Class;
     rdfs:subClassOf ids:NotificationMessage ;
     idsm:abstract true ;
     rdfs:label "Participant Notification Message"@en ;
-    rdfs:comment "Superclass of all messages, indicating a change of a particpants's conditions."@en.
+    rdfs:comment "Superclass of all messages, indicating a change of a particpants's conditions."@en;
+    idsm:validation [
+        idsm:forProperty ids:affectedParticipant;
+        idsm:constraint idsm:NotNull;
+    ].
+    
 
 ids:ParticipantAvailableMessage a owl:Class;
     rdfs:subClassOf ids:ParticipantNotificationMessage ;
@@ -159,7 +174,11 @@ ids:affectedParticipant a owl:ObjectProperty;
 ids:revokeReason
     a owl:DatatypeProperty;
     rdfs:label "revoke reason"@en;
-    rdfs:domain ids:ConnectorCertificateRevokedMessage, ids:ParticipantCertificateRevokedMessage ;
+    rdfs:domain [ owl:unionOf (
+            ids:ConnectorCertificateRevokedMessage
+            ids:ParticipantCertificateRevokedMessage
+            )
+        ];
     rdfs:range xsd:string;
     rdfs:comment "Plain Text containing the reason for revoking an existing certificate of an infrastructure component, e.g. a connector or participant."@en.
 
@@ -219,7 +238,8 @@ ids:ContractOfferMessage a owl:Class ;
 ids:ContractAgreementMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage;
     rdfs:label "Contract Agreement Message"@en;
-    rdfs:comment "Message containing a contract with resource access modalities on which two parties have agreed."@en.
+    rdfs:comment "Message containing a contract with resource access modalities on which two parties have agreed."@en;
+    .
 
 ids:ContractRejectionMessage a owl:Class ;
     rdfs:subClassOf ids:RejectionMessage;
@@ -239,7 +259,7 @@ ids:contractRejectionReason a owl:DatatypeProperty;
 
 ids:agreedContract a owl:ObjectProperty;
     rdfs:label "approved Contract"@en;
-    rdfs:domain ids:ContractSupplementMessage;
+    rdfs:domain ids:ContractAgreementMessage;
     rdfs:range ids:ContractAgreement;
     rdfs:comment "References the Contract Agreement of two parties."@en.
 
@@ -342,6 +362,10 @@ ids:OperationResultMessage  a owl:Class ;
     rdfs:label "Operation Result Message"@en;
     rdfs:comment "Message indicating that the result of a former InvokeOperation message is available. May transfer the result data in its associated payload section."@en.
 
+
+# Artifact-related Messages
+# -------------------------
+
 ids:ArtifactRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
     rdfs:label "Artifact Request Message"@en;
@@ -351,17 +375,17 @@ ids:ArtifactRequestMessage a owl:Class ;
         idsm:constraint idsm:NotNull;
     ].
 
+ids:ArtifactResponseMessage a owl:Class ;
+    rdfs:subClassOf ids:ResponseMessage;
+    rdfs:label "Artifact Response Message"@en;
+    rdfs:comment "Message that follows up a RetrieveArtifact Message and contains the Artifact's data in the payload section."@en.
+
 ids:requestedArtifact rdf:type owl:ObjectProperty ;
     idsm:referenceByUri true;
     rdfs:domain ids:ArtifactRequestMessage;
     rdfs:range ids:Artifact ;
     rdfs:label "Requested Artifact"@en ;
     rdfs:comment "References an artifact in the context of a request."@en.
-
-ids:ArtifactResponseMessage a owl:Class ;
-    rdfs:subClassOf ids:ResponseMessage;
-    rdfs:label "Artifact Response Message"@en;
-    rdfs:comment "Message that follows up a RetrieveArtifact Message and contains the Artifact's data in the payload section."@en.
 
 
 # ParIS Messages
@@ -376,18 +400,17 @@ ids:ParticipantRequestMessage a owl:Class ;
         idsm:constraint idsm:NotNull;
     ].
 
-ids:requestedParticipant rdf:type owl:DatatypeProperty ;
-    idsm:referenceByUri true;
-    rdfs:domain ids:ParticipantRequestMessage;
-    rdfs:range ids:Participant ;
-    rdfs:label "Requested Participant"@en ;
-    rdfs:comment "References a Participant in the context of a request."@en.
-
 ids:ParticipantResponseMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage;
     rdfs:label "Participant Response Message"@en;
     rdfs:comment "Message that follows up a ParticipantRequestMessage and contains the Participant's information in the payload section."@en.
 
+ids:requestedParticipant rdf:type owl:ObjectProperty ;
+    idsm:referenceByUri true;
+    rdfs:domain ids:ParticipantRequestMessage;
+    rdfs:range ids:Participant ;
+    rdfs:label "Requested Participant"@en ;
+    rdfs:comment "References a Participant in the context of a request."@en.
 
 
 # Log messaging

--- a/testing/communication/MessageShape.ttl
+++ b/testing/communication/MessageShape.ttl
@@ -25,6 +25,19 @@ shapes:MessageShape
 	a sh:NodeShape ; 
 	sh:targetClass ids:Message ;
 
+    sh:sparql [
+		a sh:SPARQLConstraint ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageShape): A ids:Message is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:prefixes shapes: ;
+		sh:select """
+			SELECT ?this ?type
+			WHERE {
+				?this rdf:type ?type .
+				FILTER (?type = ids:Message)
+			}
+		""" ;
+	] ;
+
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:modelVersion ;
@@ -56,7 +69,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:issuerConnector ;
-		sh:datatype ids:Connector ;
+		sh:datatype xsd:anyURI ;
+                sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -66,7 +80,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:recipientConnector ;
-		sh:class ids:Connector ;
+		sh:datatype xsd:anyURI ;
+        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector."@en ; 
 	] ;
@@ -74,7 +89,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:senderAgent ;
-		sh:datatype ids:Agent ;
+		sh:datatype xsd:anyURI ;
+        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:Message must have at least one ids:Agent linked through the ids:senderAgent property"@en ; 
@@ -83,7 +99,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:recipientAgent ;
-		sh:datatype ids:Agent ;
+		sh:datatype xsd:anyURI ;
+        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientAgent property must point from an ids:Message to an ids:Agent."@en ; 
 	] ;
@@ -109,7 +126,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:transferContract ;
-		sh:class ids:Contract ;
+		sh:datatype xsd:anyURI ;
+        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:transferContract property must point from an ids:Message to an ids:Contract."@en ; 
 	] ;

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -21,40 +21,9 @@ shapes:
 	] .
 
 
-shapes:RequestMessageShape
-	a sh:NodeShape ;
-	sh:targetClass ids:RequestMessage ;
-
-	sh:sparql [
-		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RequestMessageShape): An ids:RequestMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
-		sh:prefixes shapes: ;
-		sh:select """
-			SELECT ?this ?type
-			WHERE {
-				?this rdf:type ?type .
-				FILTER (?type = ids:RequestMessage)
-			}
-		""" ;
-	] .
-
-
 shapes:ResponseMessageShape
 	a sh:NodeShape ;
 	sh:targetClass ids:ResponseMessage ;
-
-	sh:sparql [
-		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:ResponseMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
-		sh:prefixes shapes: ;
-		sh:select """
-			SELECT ?this ?type
-			WHERE {
-				?this rdf:type ?type .
-				FILTER (?type = ids:ResponseMessage)
-			}
-		""" ;
-	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
@@ -66,25 +35,6 @@ shapes:ResponseMessageShape
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ResponseMessageShape): An ids:Message must have exactly one URI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
 	] .
-
-
-shapes:NotificationMessageShape
-	a sh:NodeShape ;
-	sh:targetClass ids:NotificationMessage ;
-
-	sh:sparql [
-		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (NotificationMessageShape): An ids:NotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
-		sh:prefixes shapes: ;
-		sh:select """
-			SELECT ?this ?type
-			WHERE {
-				?this rdf:type ?type .
-				FILTER (?type = ids:NotificationMessage)
-			}
-		""" ;
-	] .
-
 
 shapes:CommandMessageShape
 	a sh:NodeShape ;
@@ -108,17 +58,28 @@ shapes:QueryMessageShape
 	a sh:NodeShape ;
 	sh:targetClass ids:QueryMessage ;
 
-	sh:sparql [
-		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:QueryMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
-		sh:prefixes shapes: ;
-		sh:select """
-			SELECT ?this ?type
-			WHERE {
-				?this rdf:type ?type .
-				FILTER (?type = ids:QueryMessage)
-			}
-		""" ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:queryLanguage ;
+		sh:class ids:QueryLanguage ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:queryLanguage property must point from an ids:QueryMessage to an ids:QueryLanguage."@en ;
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:querySceope ;
+		sh:class ids:QueryScope ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:querySceope property must point from an ids:QueryMessage to an ids:QueryScope."@en ;
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:recipientScope ;
+		sh:class ids:QueryTarget ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (QueryMessageShape): An ids:recipientScope property must point from an ids:QueryMessage to an ids:QueryTarget."@en ;
 	] .
 
 
@@ -135,67 +96,77 @@ shapes:RejectionMessageShape
 	] .
 
 
-shapes:ConnectorRuntimeNotificationMessageShape
+shapes:ConnectorNotificationMessageShape
 	a sh:NodeShape ;
-	sh:targetClass ids:ConnectorRuntimeNotificationMessage ;
+	sh:targetClass ids:ConnectorNotificationMessage ;
 
 	sh:sparql [
 		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:ConnectorRuntimeNotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:ConnectorNotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
 		sh:prefixes shapes: ;
 		sh:select """
 			SELECT ?this ?type
 			WHERE {
 				?this rdf:type ?type .
-				FILTER (?type = ids:ConnectorRuntimeNotificationMessage)
+				FILTER (?type = ids:ConnectorNotificationMessage)
 			}
 		""" ;
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:revokeReason ;
+		sh:datatype xsd:string ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ConnectorNotificationMessage to xsd:string."@en ;
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:affectedConnector ;
-		sh:class ids:Connector ;
+		sh:datatype xsd:anyURI ;
+		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorRuntimeNotificationMessageShape): An ids:affectedConnector property must point from an ids:ConnectorRuntimeNotificationMessage to an ids:Connector."@en ;
+        sh:minCount 1;
+        sh:maxCount 1;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:ConnectorNotificationMessage must have exactly one URI reference to a ids:Connector linked through the ids:affectedConnector property."@en ;
 	] .
 
-
-shapes:BrokerQueryMessageShape
+shapes:ParticipantNotificationMessageShape
 	a sh:NodeShape ;
-	sh:targetClass ids:BrokerQueryMessage ;
+	sh:targetClass ids:ParticipantNotificationMessage ;
 
-	sh:property [
+	sh:sparql [
+		a sh:SPARQLConstraint ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:ParticipantNotificationMessage is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:prefixes shapes: ;
+		sh:select """
+			SELECT ?this ?type
+			WHERE {
+				?this rdf:type ?type .
+				FILTER (?type = ids:ParticipantNotificationMessage)
+			}
+		""" ;
+	] ;
+
+    sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:brokerQueryScope ;
-		sh:class ids:BrokerQueryScope ;
+		sh:path ids:revokeReason ;
+		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:brokerQueryScope property must point from an ids:BrokerQueryMessage to an ids:BrokerQueryScope."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ParticipantNotificationMessage to xsd:string."@en ;
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:queryLanguage ;
-		sh:class ids:QueryLanguage ;
+		sh:path ids:affectedParticipant ;
+		sh:datatype xsd:anyURI ;
+		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;;
+        sh:minCount 1;
+        sh:maxCount 1;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (BrokerQueryMessageShape): An ids:queryLanguage property must point from an ids:BrokerQueryMessage to an ids:QueryLanguage."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:ParticipantNotificationMessage must have exactly one URI reference to a ids:Participant linked through the ids:affectedParticipant property."@en ;
 	] .
-
-
-shapes:ContractRequestMessageShape
-	a sh:NodeShape ;
-	sh:targetClass ids:ContractRequestMessage ;
-
-	sh:property [
-		a sh:PropertyShape ;
-		sh:path ids:baseContractOffer ;
-		sh:class ids:ContractOffer ;
-		sh:minCount 1 ;
-		sh:maxCount 1 ;
-		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRequestMessageShape): An ids:ContractRequestMessage must have exactly one ids:ContractOffer linked through the ids:baseContractOffer property"@en ;
-	] .
-
 
 shapes:ContractRejectionMessageShape
 	a sh:NodeShape ;
@@ -209,19 +180,32 @@ shapes:ContractRejectionMessageShape
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to an rdf:PlainLiteral."@en ;
 	] .
 
-
-shapes:ArtifactAvailableMessageShape
+shapes:ContractSupplementMessageShape
 	a sh:NodeShape ;
-	sh:targetClass ids:ArtifactAvailableMessage ;
+	sh:targetClass ids:ContractAgreementMessage ;
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:availableArtifact ;
-		sh:datatype ids:Artifact ;
+		sh:path ids:agreedContract ;
+		sh:class ids:ContractAgreement ;
+        sh:minCount 1;
+        sh:maxCount 1;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractSupplementMessage): An ids:agreedContract property must point from an ids:ContractSupplementMessage to a URI refrence of a ids:ContractAgreement."@en ;
+	] .
+    
+shapes:ResourceNotificationMessageShape
+	a sh:NodeShape ;
+	sh:targetClass ids:ResourceNotificationMessage ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:affectedResource ;
+		sh:datatype ids:Resource ;
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactAvailableMessageShape): An ids:ArtifactAvailableMessage must have exactly one ids:Artifact linked through the ids:availableArtifact property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactAvailableMessageShape): A ids:ResourceNotificationMessage must have exactly one ids:Resource linked through the ids:affectedResource property"@en ;
 	] .
 
 
@@ -245,6 +229,7 @@ shapes:InvokeOperationMessageShape
 		sh:path ids:operationParameterization ;
 		sh:datatype ids:ParameterAssignment ;
 		sh:minCount 1 ;
+        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have at least one ids:ParameterAssignment linked through the ids:operationParameterization property"@en ;
 	] .
@@ -268,7 +253,7 @@ shapes:RequestInProcessMessageShape
 
 shapes:MessageProcessedNotificationShape
 	a sh:NodeShape ;
-	sh:targetClass ids:MessageProcessedNotification ;
+	sh:targetClass ids:MessageProcessedNotificationMessage ;
 
 	sh:property [
 		a sh:PropertyShape ;
@@ -278,9 +263,8 @@ shapes:MessageProcessedNotificationShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationShape): An ids:MessageProcessedNotification must have exactly one URI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationMessage): An ids:MessageProcessedNotificationMessage must have exactly one URI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
 	] .
-
 
 shapes:ArtifactRequestMessageShape
 	a sh:NodeShape ;
@@ -295,4 +279,21 @@ shapes:ArtifactRequestMessageShape
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ArtifactRequestMessage must have exactly one ids:Artifact linked through the ids:requestedArtifact property"@en ;
+	] .
+    
+    
+
+shapes:ParticipantRequestMessageShape
+	a sh:NodeShape ;
+	sh:targetClass ids:ParticipantRequestMessage ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:requestedParticipant ;
+		sh:datatype xsd:anyURI ;
+        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ParticipantRequestMessageShape must have exactly one ids:Participant linked through the ids:requestedParticipant property"@en ;
 	] .


### PR DESCRIPTION
Major changes:

- Remove SPARQL SHACL constraints on Request/Response/NotificationMessages, since these messages are not abstract anymore.
- Update SHACL shapes along with the changes in message classes.
- SHACL properties now expect range xsd:anyURI and also have a URI pattern constraint. This change affect message-related properties, which have _ idsm:referenceByUri true;_ in the IDS Information Model
- Renamed messages as suggested in #149 to have have more uniform naming scheme