### PR TITLE
Fix shacl properties with URI ranges.

### DIFF
--- a/testing/communication/HostShape.ttl
+++ b/testing/communication/HostShape.ttl
@@ -36,7 +36,7 @@ shapes:HostShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:accessUrl ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:accessUrl property must point from an ids:Host to an xsd:anyURI."@en ; 
 	] ;

--- a/testing/communication/HostShape.ttl
+++ b/testing/communication/HostShape.ttl
@@ -38,7 +38,7 @@ shapes:HostShape
 		sh:path ids:accessUrl ;
 		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:accessUrl property must point from an ids:Host to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/HostShape.ttl> (HostShape): An ids:accessUrl property must point from an ids:Host to an access URL via an IRI."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/communication/MessageShape.ttl
+++ b/testing/communication/MessageShape.ttl
@@ -83,7 +83,7 @@ shapes:MessageShape
 		sh:nodeKind sh:IRI ;
         sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector via an IRI."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/communication/MessageShape.ttl
+++ b/testing/communication/MessageShape.ttl
@@ -69,8 +69,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:issuerConnector ;
-		sh:datatype xsd:anyURI ;
-                sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+                sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -80,8 +80,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:recipientConnector ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientConnector property must point from an ids:Message to an ids:Connector."@en ; 
 	] ;
@@ -89,8 +89,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:senderAgent ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -100,8 +100,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:recipientAgent ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:recipientAgent property must point from an ids:Message to an ids:Agent."@en ; 
 	] ;
@@ -127,8 +127,8 @@ shapes:MessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:transferContract ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/communication/MessageShape.ttl> (MessageShape): An ids:transferContract property must point from an ids:Message to an ids:Contract."@en ; 
 	] ;

--- a/testing/content/ResourceShape.ttl
+++ b/testing/content/ResourceShape.ttl
@@ -61,7 +61,7 @@ shapes:ResourceShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:customLicense ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:customLicense property must point from an ids:Resource to an xsd:anyURI."@en ; 
 	] ;

--- a/testing/content/VocabularyDataShape.ttl
+++ b/testing/content/VocabularyDataShape.ttl
@@ -43,7 +43,7 @@ shapes:VocabularyDataShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:vocabulary ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/VocabularyDataShape.ttl> (VocabularyDataShape): An ids:vocabulary property must point from an ids:VocabularyData to an xsd:anyURI."@en ; 
 	] ;

--- a/testing/contract/ContractShape.ttl
+++ b/testing/contract/ContractShape.ttl
@@ -65,8 +65,8 @@ shapes:ContractShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:provider ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must not have more than one ids:Participant linked through the ids:provider property"@en ;
@@ -75,8 +75,8 @@ shapes:ContractShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:consumer ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:consumer property must point from an ids:Contract to an ids:Participant."@en ;
 	] ;
@@ -147,8 +147,8 @@ shapes:ContractAgreementShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:consumer ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -158,8 +158,8 @@ shapes:ContractAgreementShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:provider ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -174,8 +174,8 @@ shapes:ContractRequestShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:consumer ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
         sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -185,8 +185,8 @@ shapes:ContractRequestShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:provider ;
-		sh:datatype xsd:anyURI ;
-	   	sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+	   	sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -201,8 +201,8 @@ shapes:ContractOfferShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:provider ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;

--- a/testing/infrastructure/ConnectorShape.ttl
+++ b/testing/infrastructure/ConnectorShape.ttl
@@ -75,8 +75,8 @@ shapes:ConnectorShape
     sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:hasAgent ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): The ids:hasAgents property must point from an ids:Connector to a URI "@en ; 
 	] ;

--- a/testing/infrastructure/ConnectorShape.ttl
+++ b/testing/infrastructure/ConnectorShape.ttl
@@ -78,7 +78,7 @@ shapes:ConnectorShape
 		sh:nodeKind sh:IRI ;
         sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): The ids:hasAgents property must point from an ids:Connector to a URI "@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): The ids:hasAgents property must point from an ids:Connector to a list of Agends using an IRI."@en ; 
 	] ;
 
     sh:property [

--- a/testing/participant/ParticipantShape.ttl
+++ b/testing/participant/ParticipantShape.ttl
@@ -49,7 +49,7 @@ shapes:ParticipantShape
 		sh:path ids:corporateHomepage ;
 		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:corporateHomepage property must point from an ids:Participant to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:corporateHomepage property must point from an ids:Participant to a homepage IRI."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/participant/ParticipantShape.ttl
+++ b/testing/participant/ParticipantShape.ttl
@@ -47,7 +47,7 @@ shapes:ParticipantShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:corporateHomepage ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/participant/ParticipantShape.ttl> (ParticipantShape): An ids:corporateHomepage property must point from an ids:Participant to an xsd:anyURI."@en ; 
 	] ;

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -104,7 +104,7 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:referringConnector property must point from an ids:DatPayload to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:referringConnector property must point from an ids:DatPayload to a Connector via an IRI."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -100,7 +100,7 @@ shapes:DatPayloadShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:referringConnector ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;

--- a/testing/shared/DescribedSemanticallyShape.ttl
+++ b/testing/shared/DescribedSemanticallyShape.ttl
@@ -34,7 +34,7 @@ shapes:DescribedSemanticallyShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:shapesGraph ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedSemantically.ttl> (DescribedSemanticallyShape): An ids:shapesGraph property must point from an ids:DescribedSemantically to an xsd:anyURI."@en ; 
 	] .

--- a/testing/shared/DescribedSemanticallyShape.ttl
+++ b/testing/shared/DescribedSemanticallyShape.ttl
@@ -36,6 +36,6 @@ shapes:DescribedSemanticallyShape
 		sh:path ids:shapesGraph ;
 		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedSemantically.ttl> (DescribedSemanticallyShape): An ids:shapesGraph property must point from an ids:DescribedSemantically to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedSemantically.ttl> (DescribedSemanticallyShape): An ids:shapesGraph property must point from an ids:DescribedSemantically to an IRI."@en ; 
 	] .
 

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -29,7 +29,7 @@ shapes:DescriptionRequestMessage
 		sh:nodeKind sh:IRI ;
         sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RejectionMessageShape): An ids:requestedElement property must point from an ids:DescriptionRequestMessage to a URI."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RejectionMessageShape): An ids:requestedElement property must point from an ids:DescriptionRequestMessage to a IRI."@en ;
 	] .
 
 
@@ -179,7 +179,7 @@ shapes:ParticipantNotificationMessageShape
         sh:minCount 1;
         sh:maxCount 1;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:ParticipantNotificationMessage must have exactly one URI reference to a ids:Participant linked through the ids:affectedParticipant property."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:ParticipantNotificationMessage must have exactly one IRI reference to a ids:Participant linked through the ids:affectedParticipant property."@en ;
 	] .
 
 shapes:ContractRejectionMessageShape
@@ -235,7 +235,7 @@ shapes:InvokeOperationMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have exactly one ids:Operation linked through the ids:operationReference property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (InvokeOperationMessageShape): An ids:InvokeOperationMessage must have exactly one IRI reference to a ids:Operation linked through the ids:operationReference property"@en ;
 	] ;
 
 	sh:property [
@@ -261,7 +261,7 @@ shapes:RequestInProcessMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RequestInProcessMessageShape): An ids:RequestInProcessMessage must have exactly one URI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RequestInProcessMessageShape): An ids:RequestInProcessMessage must have exactly one IRI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
 	] .
 
 
@@ -277,7 +277,7 @@ shapes:MessageProcessedNotificationShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationMessage): An ids:MessageProcessedNotificationMessage must have exactly one URI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (MessageProcessedNotificationMessage): An ids:MessageProcessedNotificationMessage must have exactly one IRI reference to an ids:Message linked through the ids:correlationMessage property"@en ;
 	] .
 
 shapes:ArtifactRequestMessageShape
@@ -292,7 +292,7 @@ shapes:ArtifactRequestMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ArtifactRequestMessage must have exactly one ids:Artifact linked through the ids:requestedArtifact property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ArtifactRequestMessage must have exactly one IRI reference to an ids:Artifact linked through the ids:requestedArtifact property"@en ;
 	] .
     
     
@@ -309,5 +309,5 @@ shapes:ParticipantRequestMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ParticipantRequestMessageShape must have exactly one ids:Participant linked through the ids:requestedParticipant property"@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ArtifactRequestMessageShape): An ids:ParticipantRequestMessageShape must have exactly one IRI reference to an ids:Participant linked through the ids:requestedParticipant property"@en ;
 	] .

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -26,8 +26,8 @@ shapes:DescriptionRequestMessage
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:requestedElement ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (RejectionMessageShape): An ids:requestedElement property must point from an ids:DescriptionRequestMessage to a URI."@en ;
 	] .
@@ -42,8 +42,8 @@ shapes:ResponseMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:correlationMessage ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -138,8 +138,8 @@ shapes:ConnectorNotificationMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:affectedConnector ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:severity sh:Violation ;
         sh:minCount 1;
         sh:maxCount 1;
@@ -174,8 +174,8 @@ shapes:ParticipantNotificationMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:affectedParticipant ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";;
         sh:minCount 1;
         sh:maxCount 1;
 		sh:severity sh:Violation ;
@@ -230,8 +230,8 @@ shapes:InvokeOperationMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:operationReference ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -256,8 +256,8 @@ shapes:RequestInProcessMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:correlationMessage ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -272,8 +272,8 @@ shapes:MessageProcessedNotificationShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:correlationMessage ;
-		sh:datatype xsd:anyURI ;
-		sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+		sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -287,8 +287,8 @@ shapes:ArtifactRequestMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:requestedArtifact ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
@@ -304,8 +304,8 @@ shapes:ParticipantRequestMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:requestedParticipant ;
-		sh:datatype xsd:anyURI ;
-        sh:pattern "^(?:(?:http(s)?|(s)?ftp|idscp):\\/\\/)?[\\w.-]+(?:\\.[\\w\\w.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$" ;
+		sh:nodeKind sh:IRI ;
+        sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;

--- a/testing/taxonomies/RepresentationShape.ttl
+++ b/testing/taxonomies/RepresentationShape.ttl
@@ -28,7 +28,7 @@ shapes:DataRepresentationShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:dataType ;
-		sh:datatype xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataType property must point from an ids:DataRepresentation to an xsd:anyURI."@en ; 
 	] ;

--- a/testing/taxonomies/RepresentationShape.ttl
+++ b/testing/taxonomies/RepresentationShape.ttl
@@ -30,7 +30,7 @@ shapes:DataRepresentationShape
 		sh:path ids:dataType ;
 		sh:nodeKind sh:IRI ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataType property must point from an ids:DataRepresentation to an xsd:anyURI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/RepresentationShape.ttl> (DataRepresentationShape): An ids:dataType property must point from an ids:DataRepresentation to an IRI."@en ; 
 	] ;
 
 	sh:property [


### PR DESCRIPTION
SHACL shapes for properties which refer to URIs are now validated using the `sh:nodeKIind sh:IRI` constraint.
In addition, the regular expression now checks if the provided URI contains the correct prefixses. For now, we support:
http(s), (s)ftp, idscp.