### PR TITLE
Fix/shacl properties

### DIFF
--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -115,7 +115,7 @@ ids:keyword
     rdfs:subPropertyOf dcat:keyword;
     rdfs:label "keyword"@en;
     rdfs:domain ids:DigitalContent;
-    rdfs:range rdfs:Literal;
+    rdfs:range xsd:string;
     rdfs:comment "Controlled keywords that describe the nature, purpose, or use of the content."@en.
 
 ids:temporalCoverage

--- a/model/shared/Described.ttl
+++ b/model/shared/Described.ttl
@@ -33,26 +33,23 @@ ids:Described
     idsm:validation [
         idsm:forProperty ids:description;
         idsm:relationType idsm:OneToMany;
-    ];
-	idsm:validation [
-        idsm:forProperty ids:comment; #TODO: Change from ids:comment to rdfs:comment (as soon as tools support this)
-        idsm:relationType idsm:OneToMany;
-    ].
+    ] ;
+    .
 
 ids:title #.. how does it relate to "name", is "title" a functional property?
     a owl:DatatypeProperty ;
     rdfs:subPropertyOf dct:title ;
     rdfs:label "title"@en ;
     rdfs:domain ids:Described ;
-    rdfs:range rdf:PlainLiteral;
+    rdfs:range xsd:string;
     rdfs:comment "(Localized) name of the entity."@en .
 
-#TODO: change range to skos:Concept
+
 ids:description
     a owl:DatatypeProperty ;
     rdfs:subPropertyOf dct:description ;
     rdfs:label "description"@en ;
     rdfs:domain ids:Described ;
-    rdfs:range rdf:PlainLiteral ; #allows using skos:broader
+    rdfs:range xsd:string ;
     rdfs:comment "Explanation of the resource in a natural language text."@en ;
     .

--- a/model/shared/Described.ttl
+++ b/model/shared/Described.ttl
@@ -44,12 +44,13 @@ ids:title #.. how does it relate to "name", is "title" a functional property?
     rdfs:range xsd:string;
     rdfs:comment "(Localized) name of the entity."@en .
 
-
+# description is used for explanation in natural language. 
+# ids:theme (class ids:DigitalContent) is used for SKOS representation
 ids:description
     a owl:DatatypeProperty ;
     rdfs:subPropertyOf dct:description ;
     rdfs:label "description"@en ;
     rdfs:domain ids:Described ;
-    rdfs:range xsd:string ;
+    rdfs:range xsd:string ; 
     rdfs:comment "Explanation of the resource in a natural language text."@en ;
     .

--- a/model/traceability/Activity.ttl
+++ b/model/traceability/Activity.ttl
@@ -80,7 +80,7 @@ ids:ModificationActivity rdfs:subClassOf ids:Activity;
 ids:activityDescription rdfs:subPropertyOf dct:description;
     a owl:DatatypeProperty;
     rdfs:domain ids:Activity;
-    rdfs:range rdf:PlainLiteral;
+    rdfs:range xsd:string;
     rdfs:label "activityDescription"@en;
     rdfs:comment "Freetext description of what has been performed by the Activity."@en.
 

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -268,7 +268,7 @@ ids:ContractSupplementMessage a owl:Class ;
 ids:contractRejectionReason a owl:DatatypeProperty;
     rdfs:label "Contract Rejection Reason"@en ;
     rdfs:domain ids:ContractRejectionMessage;
-    rdfs:range rdf:PlainLiteral;
+    rdfs:range xsd:string;
     rdfs:comment "Human-readable text describing the reason for contract rejection."@en.
 
 ids:agreedContract a owl:ObjectProperty;

--- a/testing/content/DigitalContentShape.ttl
+++ b/testing/content/DigitalContentShape.ttl
@@ -89,9 +89,16 @@ shapes:DigitalContentShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:keyword ;
-		sh:datatype rdfs:Literal ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:keyword property must point from an ids:DigitalContent to an rdfs:Literal."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:keyword property must point from an ids:DigitalContent to a xsd:string or rdf:langString (which additionally contains a language tag)."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/content/DigitalContentShape.ttl
+++ b/testing/content/DigitalContentShape.ttl
@@ -7,6 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix shapes: <https://github.com/IndustrialDataSpace/InformationModel/testing/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 shapes:
 	a owl:Ontology ;

--- a/testing/shared/DescribedShape.ttl
+++ b/testing/shared/DescribedShape.ttl
@@ -31,24 +31,17 @@ shapes:DescribedShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:title ;
-		sh:datatype rdf:PlainLiteral ;
+		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:description ;
-		sh:class ids:Concept ;
+		sh:class xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to an ids:Concept."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to a xsd:string."@en ; 
 	] ;
-	
-	sh:property [
-		a sh:PropertyShape ;
-		sh:path ids:comment ;
-		sh:datatype rdf:PlainLiteral ;
-		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:comment property must point from an ids:Described to an rdf:PlainLiteral."@en ; 
-	] .
+ .
 

--- a/testing/shared/DescribedShape.ttl
+++ b/testing/shared/DescribedShape.ttl
@@ -46,7 +46,14 @@ shapes:DescribedShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:description ;
-		sh:class xsd:string ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to either a xsd:string or a rdf:langString with a language code"@en ; 
 	] ;

--- a/testing/shared/DescribedShape.ttl
+++ b/testing/shared/DescribedShape.ttl
@@ -31,9 +31,16 @@ shapes:DescribedShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:title ;
-		sh:datatype xsd:string ;
+        sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:title property must point from an ids:Described to either a xsd:string or a rdf:langString with a language code."@en ; 
 	] ;
 
 	sh:property [
@@ -41,7 +48,7 @@ shapes:DescribedShape
 		sh:path ids:description ;
 		sh:class xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to a xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/shared/DescribedShape.ttl> (DescribedShape): An ids:description property must point from an ids:Described to either a xsd:string or a rdf:langString with a language code"@en ; 
 	] ;
  .
 

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -192,9 +192,9 @@ shapes:ContractRejectionMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:contractRejectionReason ;
-		sh:datatype rdf:PlainLiteral ;
+		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to an rdf:PlainLiteral."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to a xsd:string."@en ;
 	] .
 
 shapes:ContractSupplementMessageShape

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -131,9 +131,16 @@ shapes:ConnectorNotificationMessageShape
     sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:revokeReason ;
-		sh:datatype xsd:string ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ConnectorNotificationMessage to xsd:string."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ConnectorNotificationMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
 	] ;
 
 	sh:property [
@@ -168,9 +175,16 @@ shapes:ParticipantNotificationMessageShape
     sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:revokeReason ;
-		sh:datatype xsd:string ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ParticipantNotificationMessage to xsd:string."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ParticipantNotificationMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
 	] ;
 
 	sh:property [
@@ -192,9 +206,16 @@ shapes:ContractRejectionMessageShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:contractRejectionReason ;
-		sh:datatype xsd:string ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to a xsd:string."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ContractRejectionMessageShape): An ids:contractRejectionReason property must point from an ids:ContractRejectionMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
 	] .
 
 shapes:ContractSupplementMessageShape

--- a/testing/traceability/ActivityShape.ttl
+++ b/testing/traceability/ActivityShape.ttl
@@ -42,9 +42,9 @@ shapes:ActivityShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:activityDescription ;
-		sh:datatype rdf:PlainLiteral ;
+		sh:datatype xsd:string ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to an rdf:PlainLiteral."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to a xsd:string."@en ; 
 	] ;
 
 	sh:property [

--- a/testing/traceability/ActivityShape.ttl
+++ b/testing/traceability/ActivityShape.ttl
@@ -42,9 +42,16 @@ shapes:ActivityShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:activityDescription ;
-		sh:datatype xsd:string ;
+		sh:or (
+            [
+                sh:datatype xsd:string ;
+			]
+			[
+                sh:datatype rdf:langString ;
+            ]
+            );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to a xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/traceability/ActivityShape.ttl> (ActivityShape): An ids:activityDescription property must point from an ids:Activity to either a xsd:string or a rdf:langString which contains a language code.."@en ; 
 	] ;
 
 	sh:property [


### PR DESCRIPTION
- Replace rdf:PlainLiteral with xsd:string
- Update shacl shapes
- Remove annotation property for already deleted ids:comment
- expand shacl to also allow using `rdf:langstring` for some datatype proerties in addition to xsd:string. This allows tagging xstring values with language codes.


@maboeckmann Could you test with your build tools and stuff in advance ?