### PR TITLE
Fixing property name in shapes

### DIFF
--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -130,7 +130,7 @@ shapes:ConnectorNotificationMessageShape
     
     sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:revokeReason ;
+		sh:path ids:revocationReason ;
 		sh:or (
             [
                 sh:datatype xsd:string ;
@@ -140,7 +140,7 @@ shapes:ConnectorNotificationMessageShape
             ]
             );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ConnectorNotificationMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ConnectorNotificationMessage): An ids:revocationReason property must point from a subclass of ids:ConnectorNotificationMessage to either an xsd:string or an rdf:langString, which also contains a language code."@en ;
 	] ;
 
 	sh:property [
@@ -174,7 +174,7 @@ shapes:ParticipantNotificationMessageShape
 
     sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:revokeReason ;
+		sh:path ids:revocationReason ;
 		sh:or (
             [
                 sh:datatype xsd:string ;
@@ -184,7 +184,7 @@ shapes:ParticipantNotificationMessageShape
             ]
             );
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:revokeReason property must point from a subclass of ids:ParticipantNotificationMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (ParticipantNotificationMessage): An ids:revocationReason property must point from a subclass of ids:ParticipantNotificationMessage to either a xsd:string or rdf:langString which also contains a language code."@en ;
 	] ;
 
 	sh:property [


### PR DESCRIPTION
We renamed revokeReason to recovationReason in the model, but did not update the SHACL shapes accordingly.