### PR TITLE
Remove unnecessary semicolon to fix parsing error.

### DIFF
--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -53,7 +53,7 @@ shapes:RequestMessageShape
 shapes:NotificationMessageShape
 	a sh:NodeShape ;
 	sh:targetClass ids:NotificationMessage ;
- ;
+ 
 
 	sh:property [
 		a sh:PropertyShape ;


### PR DESCRIPTION
When I checked if the changes from _Catalog Title+Description #521_ were working with the CodeGen Tool, it throws a parsing error for this duplicate semicolon. After removing it, everything was fine.
Therefore, I would recommend to remove it to maybe prevent other tools using the ontology from having the same problem :-) 